### PR TITLE
[FEAT] 멘토링 카테고리 및 멘토링 도메인 모델링

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,7 +1,7 @@
 language: "ko-KR"
 
 reviews:
-  profile: "assertive"
+  profile: "chill"
   request_changes_workflow: true
   high_level_summary: true
   poem: false

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -20,4 +20,4 @@ jobs:
         run: chmod +x ./gradlew
         
       - name: Check code formatting with Spotless
-        run: ./gradlew spotlessCheck
+        run: ./gradlew spotlessCheck -PGitHubPackagesUsername=${{ github.actor }} -PGitHubPackagesPassword=${{ secrets.GITHUB_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,7 @@ logs/
 Thumbs.db
 
 # Secrets
+gradle.properties
 application-secret.yml
 application-secret.yaml
 application-prod.yml

--- a/HELP.md
+++ b/HELP.md
@@ -2,7 +2,7 @@
 
 The following was discovered as part of building this project:
 
-* The original package name 'com.goggles.mentoring-server' is invalid and this project uses 'com.goggles.mentoring_server' instead.
+* The original package name 'com.goggles.mentoring-service' is invalid and this project uses 'com.goggles.mentoring_service' instead.
 
 # Getting Started
 

--- a/README.md
+++ b/README.md
@@ -1,0 +1,29 @@
+# Mentoring Service
+
+## 로컬 개발 환경 설정
+
+### GitHub Packages 인증
+
+이 프로젝트는 `com.goggles:common-library`를 GitHub Packages에서 가져옵니다.
+로컬에서 빌드하려면 GitHub Personal Access Token(PAT)이 필요합니다.
+
+**1. PAT 발급**
+
+GitHub → Settings → Developer settings → Personal access tokens → Tokens (classic)
+
+권한: `read:packages`
+
+**2. gradle.properties 설정**
+
+```bash
+cp gradle.properties.template gradle.properties
+```
+
+`gradle.properties`를 열어 발급받은 값으로 채웁니다.
+
+```properties
+GitHubPackagesUsername=깃허브_유저네임
+GitHubPackagesPassword=발급받은_PAT
+```
+
+> `gradle.properties`는 `.gitignore`에 등록되어 있으므로 커밋되지 않습니다.

--- a/build.gradle
+++ b/build.gradle
@@ -23,6 +23,13 @@ configurations {
 
 repositories {
 	mavenCentral()
+	maven {
+		url = uri("https://maven.pkg.github.com/9oogle/common-library")
+		credentials {
+			username = providers.gradleProperty("GitHubPackagesUsername").get()
+			password = providers.gradleProperty("GitHubPackagesPassword").get()
+		}
+	}
 }
 
 ext {
@@ -41,12 +48,6 @@ dependencies {
 	runtimeOnly 'org.postgresql:postgresql'
 	compileOnly 'org.projectlombok:lombok'
 	annotationProcessor 'org.projectlombok:lombok'
-	testCompileOnly 'org.projectlombok:lombok'
-	testAnnotationProcessor 'org.projectlombok:lombok'
-	testImplementation 'org.springframework.boot:spring-boot-starter-test'
-
-	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
-	testRuntimeOnly 'com.h2database:h2'
 
 	implementation 'org.springframework.cloud:spring-cloud-starter-netflix-eureka-client'
 	implementation 'org.springframework.cloud:spring-cloud-starter-openfeign'
@@ -59,6 +60,15 @@ dependencies {
 	implementation 'io.micrometer:micrometer-tracing-bridge-brave'
 	implementation 'io.zipkin.reporter2:zipkin-reporter-brave'
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.16'
+
+	implementation 'com.goggles:common-library:1.0.0'
+
+	testCompileOnly 'org.projectlombok:lombok'
+	testAnnotationProcessor 'org.projectlombok:lombok'
+	testImplementation 'org.springframework.boot:spring-boot-starter-test'
+
+	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+	testRuntimeOnly 'com.h2database:h2'
 }
 
 tasks.named('test') {

--- a/gradle.properties.template
+++ b/gradle.properties.template
@@ -1,0 +1,2 @@
+GitHubPackagesUsername=YOUR_GITHUB_USERNAME
+GitHubPackagesPassword=YOUR_GITHUB_PERSONAL_ACCESS_TOKEN

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,1 +1,1 @@
-rootProject.name = 'mentoring-server'
+rootProject.name = 'mentoring-service'

--- a/src/main/java/com/goggles/mentoring_service/MentoringServerApplication.java
+++ b/src/main/java/com/goggles/mentoring_service/MentoringServerApplication.java
@@ -1,4 +1,4 @@
-package com.goggles.mentoring_server;
+package com.goggles.mentoring_service;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;

--- a/src/main/java/com/goggles/mentoring_service/domain/BookingType.java
+++ b/src/main/java/com/goggles/mentoring_service/domain/BookingType.java
@@ -1,0 +1,5 @@
+package com.goggles.mentoring_service.domain;
+
+public enum BookingType {
+	ONE_TIME, SELF_SELECT, AUTO_REPEAT
+}

--- a/src/main/java/com/goggles/mentoring_service/domain/Mentor.java
+++ b/src/main/java/com/goggles/mentoring_service/domain/Mentor.java
@@ -1,0 +1,45 @@
+package com.goggles.mentoring_service.domain;
+
+
+import com.goggles.mentoring_service.domain.exception.InvalidMentorUserTypeException;
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+import lombok.*;
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.type.SqlTypes;
+
+import java.util.UUID;
+
+@Embeddable
+@Getter
+@ToString
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Mentor {
+
+	private static final UserType ALLOWED_USER_TYPE = UserType.INSTRUCTOR;
+
+	@JdbcTypeCode(SqlTypes.UUID)
+	@Column(name = "mentor_id", nullable = false)
+	private UUID id;
+
+	@Column(name = "mentor_name",length = 100, nullable = false)
+	private String name;
+
+	@Column(name= "mentor_field", length = 100, nullable = false)
+	private String field;
+
+	@Builder
+	protected Mentor(UUID id, String name, String field, UserType userType) {
+		checkIfMentorAuthValidate(id, userType);
+		this.id = id;
+		this.name = name;
+		this.field = field;
+	}
+
+	private static void checkIfMentorAuthValidate(UUID id, UserType userType) {
+		if (userType != ALLOWED_USER_TYPE) {
+			throw new InvalidMentorUserTypeException(id, userType);
+		}
+	}
+
+}

--- a/src/main/java/com/goggles/mentoring_service/domain/Mentoring.java
+++ b/src/main/java/com/goggles/mentoring_service/domain/Mentoring.java
@@ -1,0 +1,167 @@
+package com.goggles.mentoring_service.domain;
+
+import com.goggles.common.domain.BaseAudit;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.SQLRestriction;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.util.ArrayList;
+import java.util.List;
+
+
+@Getter
+@Entity
+@Table(name = "P_MENTORING")
+@Access(AccessType.FIELD)
+@SQLRestriction("deleted_at IS NULL")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Mentoring extends BaseAudit {
+
+	@EmbeddedId
+	private MentoringId mentoringId;
+
+	@Embedded
+	private Mentor mentor;
+
+	@Embedded
+	private MentoringCategorySnapshot mentoringCategory;
+
+	@Column(length = 100, nullable = false)
+	private String title;
+
+	private String subtitle;
+
+	@Column(columnDefinition = "TEXT")
+	private String description;
+
+	private MentoringDuration duration;
+
+	private MentoringStatus status = MentoringStatus.INACTIVE;
+
+	private BookingType bookingType = BookingType.ONE_TIME;
+
+	private MentoringType mentoringType = MentoringType.ONE_ON_ONE;
+
+	private int sessionCount = 1;
+
+	private int maxParticipants = 1;
+
+	private LocalDate endDate;
+
+	private boolean excludeHolidays;
+
+	@ElementCollection(fetch = FetchType.LAZY)
+	@CollectionTable(name = "P_REPEAT_PATTERN", joinColumns = @JoinColumn(name = "mentoring_id"))
+	@OrderColumn(name = "pattern_order")
+	private List<RepeatPattern> repeatPatterns = new ArrayList<>();
+
+	@ElementCollection(fetch = FetchType.LAZY)
+	@CollectionTable(name = "P_MENTORING_SESSION", joinColumns = @JoinColumn(name = "mentoring_id"))
+	@OrderColumn(name = "session_order")
+	private List<MentoringSession> sessions = new ArrayList<>();
+
+
+	private Mentoring(Mentor mentor, MentoringCategorySnapshot mentoringCategory, String title,
+			String subtitle, String description, MentoringDuration duration,
+			MentoringStatus status, MentoringType mentoringType,
+			BookingType bookingType, int sessionCount, int maxParticipants, boolean excludeHolidays) {
+		validateTypeConstraints(mentoringType, bookingType, sessionCount, maxParticipants);
+		this.mentoringId = MentoringId.of();
+		this.mentor = mentor;
+		this.mentoringCategory = mentoringCategory;
+		this.title = title;
+		this.subtitle = subtitle;
+		this.description = description;
+		this.duration = duration;
+		this.status = status;
+		this.bookingType = bookingType;
+		this.mentoringType = mentoringType;
+		this.sessionCount = sessionCount;
+		this.maxParticipants = maxParticipants;
+		this.excludeHolidays = excludeHolidays;
+	}
+
+	private static void validateTypeConstraints(MentoringType mentoringType, BookingType bookingType,
+			int sessionCount, int maxParticipants) {
+		if (mentoringType == MentoringType.GROUP && maxParticipants <= 1) {
+			throw new IllegalArgumentException("그룹 멘토링은 최대 참여자 수가 2명 이상이어야 합니다.");
+		}
+		if (mentoringType == MentoringType.ONE_ON_ONE && maxParticipants != 1) {
+			throw new IllegalArgumentException("1:1 멘토링의 최대 참여자 수는 1명이어야 합니다.");
+		}
+		if (bookingType == BookingType.SELF_SELECT && sessionCount <= 1) {
+			throw new IllegalArgumentException("자유 선택 예약은 세션 수가 2회 이상이어야 합니다.");
+		}
+	}
+
+	@Builder
+	public static Mentoring create(Mentor mentor, MentoringCategorySnapshot mentoringCategory, String title,
+			String subtitle, String description, MentoringDuration duration,
+			MentoringStatus status,MentoringType mentoringType,
+			BookingType bookingType, int sessionCount, int maxParticipants, boolean excludeHolidays) {
+		return new Mentoring(mentor, mentoringCategory, title, subtitle, description, duration,
+				status, mentoringType,bookingType, sessionCount, maxParticipants, excludeHolidays);
+	}
+
+	public void activate() {
+		if (bookingType == BookingType.AUTO_REPEAT && repeatPatterns.isEmpty()) {
+			throw new IllegalStateException("자동 반복 멘토링은 요일 반복 패턴이 설정되어야 활성화할 수 있습니다.");
+		}
+		this.status = MentoringStatus.ACTIVE;
+	}
+
+	public void deactivate() {
+		this.status = MentoringStatus.INACTIVE;
+	}
+
+	public void updateEndDate(LocalDate newEndDate) {
+		this.endDate = newEndDate;
+	}
+
+	public void updateRepeatPatterns(List<RepeatPattern> newPatterns) {
+		this.repeatPatterns.clear();
+		this.repeatPatterns.addAll(newPatterns);
+	}
+
+	public void addSessions(List<MentoringSession> sessions) {
+		this.sessions.addAll(sessions);
+	}
+
+	public void updateSessions(List<MentoringSession> newSessions) {
+		this.sessions.removeIf(session -> session.getSessionDate()
+				.isAfter(LocalDate.now()) && !session.isBooked());
+		this.sessions.addAll(newSessions);
+	}
+
+	public void removeSessions(List<MentoringSession> sessionsToRemove) {
+		if(sessionsToRemove.stream().anyMatch(MentoringSession::isBooked)) {
+			throw new IllegalStateException("예약된 세션은 삭제할 수 없습니다.");
+		}
+		this.sessions.removeAll(sessionsToRemove);
+	}
+
+	public void deactivateSession(LocalDate date, LocalTime startTime) {
+		findSession(date, startTime).deactivate();
+	}
+
+	public void activateSession(LocalDate date, LocalTime startTime) {
+		findSession(date, startTime).activate();
+	}
+
+	public void bookSession(LocalDate date, LocalTime startTime) {
+		findSession(date, startTime).book();
+	}
+
+	private MentoringSession findSession(LocalDate date, LocalTime startTime) {
+		return this.sessions.stream()
+				.filter(s -> s.getSessionDate().equals(date) && s.getSessionStartTime().equals(startTime))
+				.findFirst()
+				.orElseThrow(() -> new IllegalArgumentException("해당 날짜와 시간에 세션이 존재하지 않습니다."));
+	}
+
+}

--- a/src/main/java/com/goggles/mentoring_service/domain/Mentoring.java
+++ b/src/main/java/com/goggles/mentoring_service/domain/Mentoring.java
@@ -8,6 +8,11 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.SQLRestriction;
 
+import com.goggles.mentoring_service.domain.exception.BookedSessionCannotBeDeletedException;
+import com.goggles.mentoring_service.domain.exception.InvalidMentoringPolicyException;
+import com.goggles.mentoring_service.domain.exception.RepeatPatternRequiredException;
+import com.goggles.mentoring_service.domain.exception.SessionNotFoundException;
+
 import java.time.LocalDate;
 import java.time.LocalTime;
 import java.util.ArrayList;
@@ -89,13 +94,13 @@ public class Mentoring extends BaseAudit {
 	private static void validateTypeConstraints(MentoringType mentoringType, BookingType bookingType,
 			int sessionCount, int maxParticipants) {
 		if (mentoringType == MentoringType.GROUP && maxParticipants <= 1) {
-			throw new IllegalArgumentException("그룹 멘토링은 최대 참여자 수가 2명 이상이어야 합니다.");
+			throw new InvalidMentoringPolicyException("그룹 멘토링은 최대 참여자 수가 2명 이상이어야 합니다.");
 		}
 		if (mentoringType == MentoringType.ONE_ON_ONE && maxParticipants != 1) {
-			throw new IllegalArgumentException("1:1 멘토링의 최대 참여자 수는 1명이어야 합니다.");
+			throw new InvalidMentoringPolicyException("1:1 멘토링의 최대 참여자 수는 1명이어야 합니다.");
 		}
 		if (bookingType == BookingType.SELF_SELECT && sessionCount <= 1) {
-			throw new IllegalArgumentException("자유 선택 예약은 세션 수가 2회 이상이어야 합니다.");
+			throw new InvalidMentoringPolicyException("자유 선택 예약은 세션 수가 2회 이상이어야 합니다.");
 		}
 	}
 
@@ -110,7 +115,7 @@ public class Mentoring extends BaseAudit {
 
 	public void activate() {
 		if (bookingType == BookingType.AUTO_REPEAT && repeatPatterns.isEmpty()) {
-			throw new IllegalStateException("자동 반복 멘토링은 요일 반복 패턴이 설정되어야 활성화할 수 있습니다.");
+			throw new RepeatPatternRequiredException();
 		}
 		this.status = MentoringStatus.ACTIVE;
 	}
@@ -139,8 +144,8 @@ public class Mentoring extends BaseAudit {
 	}
 
 	public void removeSessions(List<MentoringSession> sessionsToRemove) {
-		if(sessionsToRemove.stream().anyMatch(MentoringSession::isBooked)) {
-			throw new IllegalStateException("예약된 세션은 삭제할 수 없습니다.");
+		if (sessionsToRemove.stream().anyMatch(MentoringSession::isBooked)) {
+			throw new BookedSessionCannotBeDeletedException();
 		}
 		this.sessions.removeAll(sessionsToRemove);
 	}
@@ -161,7 +166,7 @@ public class Mentoring extends BaseAudit {
 		return this.sessions.stream()
 				.filter(s -> s.getSessionDate().equals(date) && s.getSessionStartTime().equals(startTime))
 				.findFirst()
-				.orElseThrow(() -> new IllegalArgumentException("해당 날짜와 시간에 세션이 존재하지 않습니다."));
+				.orElseThrow(() -> new SessionNotFoundException(date, startTime));
 	}
 
 }

--- a/src/main/java/com/goggles/mentoring_service/domain/MentoringCategory.java
+++ b/src/main/java/com/goggles/mentoring_service/domain/MentoringCategory.java
@@ -1,0 +1,108 @@
+package com.goggles.mentoring_service.domain;
+
+import com.goggles.common.domain.BaseAudit;
+import com.goggles.mentoring_service.domain.exception.InactiveCategoryCannotMoveException;
+import com.goggles.mentoring_service.domain.exception.InvalidMentoringCategoryAdminUserTypeException;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+import org.hibernate.annotations.SQLRestriction;
+
+import java.util.UUID;
+
+/**
+ * Partial Unique Indexes for Active Categories:
+ *
+ * CREATE UNIQUE INDEX uq_mentoring_category_code_active
+ * ON p_mentoring_category (code)
+ * WHERE deleted_at IS NULL;
+ *
+ * CREATE UNIQUE INDEX uq_mentoring_category_name_active
+ * ON p_mentoring_category (name)
+ * WHERE deleted_at IS NULL;
+ *
+ * CREATE UNIQUE INDEX uq_mentoring_category_sort_active
+ * ON p_mentoring_category (sort_order)
+ * WHERE is_active = true;
+ */
+
+@Getter
+@Entity @ToString
+@Table(name = "P_MENTORING_CATEGORY")
+@Access(AccessType.FIELD)
+@SQLRestriction("deleted_at IS NULL")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class MentoringCategory extends BaseAudit {
+
+	@EmbeddedId
+	private MentoringCategoryId mentoringCategoryId;
+
+	@Column(length=50, nullable = false)
+	private String name;
+
+	@Column(length = 10, nullable = false)
+	private String code;
+
+	// 0부터 시작하는 정수로, 활성화된 카테고리들 사이에서의 순서를 나타냄. 비활성 시 null
+	private Integer sortOrder;
+
+	private boolean active;
+
+	private MentoringCategory(String name, String code) {
+		this.mentoringCategoryId = MentoringCategoryId.of();
+		this.name = name;
+		this.code = code;
+		this.sortOrder = null;
+		this.active = false;
+	}
+
+	public static MentoringCategory create(UUID userId,UserType type, String name, String code) {
+		checkIfUserTypeIsAdmin(userId, type);
+		 return new MentoringCategory(name, code);
+	}
+
+	public void softDelete(UUID userId,UserType type) {
+		checkIfUserTypeIsAdmin(userId, type);
+		this.softDelete(userId);
+		this.active = false;
+		this.sortOrder = null;
+	}
+
+	public void updateNameAndCode(UUID userId,UserType type, String name, String code) {
+		checkIfUserTypeIsAdmin(userId, type);
+		this.name = name;
+		this.code = code;
+	}
+
+	public void activate(UUID userId,UserType type, int sortOrder) {
+		checkIfUserTypeIsAdmin(userId, type);
+		this.sortOrder = sortOrder;
+		this.active = true;
+	}
+
+	public void deactivate(UUID userId,UserType type) {
+		checkIfUserTypeIsAdmin(userId, type);
+		this.active = false;
+		this.sortOrder = null;
+	}
+
+	public void move(UUID userId,UserType type, int newSortOrder) {
+		checkIfUserTypeIsAdmin(userId, type);
+		checkActivation();
+		this.sortOrder = newSortOrder;
+	}
+
+	private void checkActivation() {
+		if(!this.active) {
+			throw new InactiveCategoryCannotMoveException();
+		}
+	}
+
+	private static void checkIfUserTypeIsAdmin(UUID userId, UserType type) {
+		if (type != UserType.MASTER) {
+			throw new InvalidMentoringCategoryAdminUserTypeException(userId, type);
+		}
+	}
+}

--- a/src/main/java/com/goggles/mentoring_service/domain/MentoringCategoryId.java
+++ b/src/main/java/com/goggles/mentoring_service/domain/MentoringCategoryId.java
@@ -1,0 +1,24 @@
+package com.goggles.mentoring_service.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.type.SqlTypes;
+
+import java.io.Serializable;
+import java.util.UUID;
+
+@Embeddable
+public record MentoringCategoryId(@JdbcTypeCode(SqlTypes.UUID)
+								  @Column(length=50, name="mentoring_category_id")
+	UUID categoryId
+) implements Serializable {
+
+	public static MentoringCategoryId of(){
+		return new MentoringCategoryId(UUID.randomUUID());
+	}
+
+	public static MentoringCategoryId of(String mentoringCategoryIdString){
+		return new MentoringCategoryId(UUID.fromString(mentoringCategoryIdString));
+	}
+}

--- a/src/main/java/com/goggles/mentoring_service/domain/MentoringCategoryRepository.java
+++ b/src/main/java/com/goggles/mentoring_service/domain/MentoringCategoryRepository.java
@@ -2,11 +2,13 @@ package com.goggles.mentoring_service.domain;
 
 import java.util.List;
 import java.util.Optional;
-import java.util.UUID;
 
 public interface MentoringCategoryRepository {
 	MentoringCategory save(MentoringCategory category);
+
 	void saveAll(List<MentoringCategory> categories);
-	Optional<MentoringCategory> findById(UUID mentoringCategoryId);
+
+	Optional<MentoringCategory> findById(MentoringCategoryId id);
+
 	List<MentoringCategory> findByActiveIsTrue();
 }

--- a/src/main/java/com/goggles/mentoring_service/domain/MentoringCategoryRepository.java
+++ b/src/main/java/com/goggles/mentoring_service/domain/MentoringCategoryRepository.java
@@ -1,0 +1,12 @@
+package com.goggles.mentoring_service.domain;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+public interface MentoringCategoryRepository {
+	MentoringCategory save(MentoringCategory category);
+	void saveAll(List<MentoringCategory> categories);
+	Optional<MentoringCategory> findById(UUID mentoringCategoryId);
+	List<MentoringCategory> findByActiveIsTrue();
+}

--- a/src/main/java/com/goggles/mentoring_service/domain/MentoringCategorySnapshot.java
+++ b/src/main/java/com/goggles/mentoring_service/domain/MentoringCategorySnapshot.java
@@ -1,0 +1,9 @@
+package com.goggles.mentoring_service.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+
+@Embeddable
+public record MentoringCategorySnapshot(MentoringCategoryId mentoringCategoryId,
+										@Column(length = 50, name = "mentoring_category_name") String name,
+										@Column(length = 10, name = "mentoring_category_code") String code) {}

--- a/src/main/java/com/goggles/mentoring_service/domain/MentoringDuration.java
+++ b/src/main/java/com/goggles/mentoring_service/domain/MentoringDuration.java
@@ -1,0 +1,19 @@
+package com.goggles.mentoring_service.domain;
+
+import lombok.Getter;
+
+public enum MentoringDuration {
+	MINUTES_30(30),
+	MINUTES_60(60),
+	MINUTES_90(90),
+	MINUTES_120(120),
+	MINUTES_150(150),
+	MINUTES_180(180);
+
+	@Getter
+	private final int minutes;
+
+	MentoringDuration(int minutes) {
+		this.minutes = minutes;
+	}
+}

--- a/src/main/java/com/goggles/mentoring_service/domain/MentoringId.java
+++ b/src/main/java/com/goggles/mentoring_service/domain/MentoringId.java
@@ -1,0 +1,24 @@
+package com.goggles.mentoring_service.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.type.SqlTypes;
+
+import java.io.Serializable;
+import java.util.UUID;
+
+@Embeddable
+public record MentoringId (@JdbcTypeCode(SqlTypes.UUID)
+						   @Column(length=36, name="mentoring_id")
+	UUID mentoringId
+) implements Serializable {
+
+	public static MentoringId of(){
+		return new MentoringId(UUID.randomUUID());
+	}
+
+	public static MentoringId of(String mentoringIdString){
+		return new MentoringId(UUID.fromString(mentoringIdString));
+	}
+}

--- a/src/main/java/com/goggles/mentoring_service/domain/MentoringRepository.java
+++ b/src/main/java/com/goggles/mentoring_service/domain/MentoringRepository.java
@@ -1,0 +1,8 @@
+package com.goggles.mentoring_service.domain;
+
+import java.util.UUID;
+
+public interface MentoringRepository {
+	void save(Mentoring mentoring);
+	Mentoring findById(UUID id);
+}

--- a/src/main/java/com/goggles/mentoring_service/domain/MentoringRepository.java
+++ b/src/main/java/com/goggles/mentoring_service/domain/MentoringRepository.java
@@ -1,8 +1,9 @@
 package com.goggles.mentoring_service.domain;
 
+import java.util.Optional;
 import java.util.UUID;
 
 public interface MentoringRepository {
 	void save(Mentoring mentoring);
-	Mentoring findById(UUID id);
+	Optional<Mentoring> findById(MentoringId id);
 }

--- a/src/main/java/com/goggles/mentoring_service/domain/MentoringSession.java
+++ b/src/main/java/com/goggles/mentoring_service/domain/MentoringSession.java
@@ -1,5 +1,7 @@
 package com.goggles.mentoring_service.domain;
 
+import com.goggles.mentoring_service.domain.exception.BookedSessionStatusCannotBeChangedException;
+import com.goggles.mentoring_service.domain.exception.SessionNotAvailableException;
 import jakarta.persistence.Embeddable;
 import lombok.*;
 
@@ -27,14 +29,14 @@ public class MentoringSession {
 
 	public void deactivate() {
 		if (this.status == SessionStatus.BOOKED) {
-			throw new IllegalStateException("예약된 세션은 상태를 변경할 수 없습니다.");
+			throw new BookedSessionStatusCannotBeChangedException();
 		}
 		this.status = SessionStatus.NOT_AVAILABLE;
 	}
 
 	public void activate() {
 		if (this.status == SessionStatus.BOOKED) {
-			throw new IllegalStateException("예약된 세션은 상태를 변경할 수 없습니다.");
+			throw new BookedSessionStatusCannotBeChangedException();
 		}
 		this.status = SessionStatus.AVAILABLE;
 	}
@@ -45,7 +47,7 @@ public class MentoringSession {
 
 	public void book() {
 		if (this.status != SessionStatus.AVAILABLE) {
-			throw new IllegalStateException("예약 가능한 세션이 아닙니다.");
+			throw new SessionNotAvailableException();
 		}
 		this.status = SessionStatus.BOOKED;
 	}

--- a/src/main/java/com/goggles/mentoring_service/domain/MentoringSession.java
+++ b/src/main/java/com/goggles/mentoring_service/domain/MentoringSession.java
@@ -1,0 +1,52 @@
+package com.goggles.mentoring_service.domain;
+
+import jakarta.persistence.Embeddable;
+import lombok.*;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+
+@Embeddable
+@Getter
+@ToString
+@EqualsAndHashCode(of = {"sessionDate", "sessionStartTime"})
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class MentoringSession {
+	private LocalDate sessionDate;
+	private LocalTime sessionStartTime;
+	private LocalTime sessionEndTime;
+	private SessionStatus status = SessionStatus.AVAILABLE;
+
+	public static MentoringSession of(LocalDate date, LocalTime startTime, LocalTime endTime) {
+		MentoringSession session = new MentoringSession();
+		session.sessionDate = date;
+		session.sessionStartTime = startTime;
+		session.sessionEndTime = endTime;
+		return session;
+	}
+
+	public void deactivate() {
+		if (this.status == SessionStatus.BOOKED) {
+			throw new IllegalStateException("예약된 세션은 상태를 변경할 수 없습니다.");
+		}
+		this.status = SessionStatus.NOT_AVAILABLE;
+	}
+
+	public void activate() {
+		if (this.status == SessionStatus.BOOKED) {
+			throw new IllegalStateException("예약된 세션은 상태를 변경할 수 없습니다.");
+		}
+		this.status = SessionStatus.AVAILABLE;
+	}
+
+	public boolean isBooked() {
+		return this.status == SessionStatus.BOOKED;
+	}
+
+	public void book() {
+		if (this.status != SessionStatus.AVAILABLE) {
+			throw new IllegalStateException("예약 가능한 세션이 아닙니다.");
+		}
+		this.status = SessionStatus.BOOKED;
+	}
+}

--- a/src/main/java/com/goggles/mentoring_service/domain/MentoringSession.java
+++ b/src/main/java/com/goggles/mentoring_service/domain/MentoringSession.java
@@ -19,33 +19,36 @@ public class MentoringSession {
 	private LocalTime sessionEndTime;
 	private SessionStatus status = SessionStatus.AVAILABLE;
 
-	public static MentoringSession of(LocalDate date, LocalTime startTime, LocalTime endTime) {
+	 static MentoringSession of(LocalDate date, LocalTime startTime, LocalTime endTime) {
 		MentoringSession session = new MentoringSession();
 		session.sessionDate = date;
+		if(startTime.isAfter(endTime) || startTime.equals(endTime)) {
+			throw new IllegalArgumentException("세션의 시작 시간은 종료 시간보다 이전이어야 합니다.");
+		}
 		session.sessionStartTime = startTime;
 		session.sessionEndTime = endTime;
 		return session;
 	}
 
-	public void deactivate() {
+	 void deactivate() {
 		if (this.status == SessionStatus.BOOKED) {
 			throw new BookedSessionStatusCannotBeChangedException();
 		}
 		this.status = SessionStatus.NOT_AVAILABLE;
 	}
 
-	public void activate() {
+	 void activate() {
 		if (this.status == SessionStatus.BOOKED) {
 			throw new BookedSessionStatusCannotBeChangedException();
 		}
 		this.status = SessionStatus.AVAILABLE;
 	}
 
-	public boolean isBooked() {
+	 boolean isBooked() {
 		return this.status == SessionStatus.BOOKED;
 	}
 
-	public void book() {
+	 void book() {
 		if (this.status != SessionStatus.AVAILABLE) {
 			throw new SessionNotAvailableException();
 		}

--- a/src/main/java/com/goggles/mentoring_service/domain/MentoringStatus.java
+++ b/src/main/java/com/goggles/mentoring_service/domain/MentoringStatus.java
@@ -1,0 +1,6 @@
+package com.goggles.mentoring_service.domain;
+
+public enum MentoringStatus {
+	ACTIVE,
+	INACTIVE
+}

--- a/src/main/java/com/goggles/mentoring_service/domain/MentoringType.java
+++ b/src/main/java/com/goggles/mentoring_service/domain/MentoringType.java
@@ -1,0 +1,6 @@
+package com.goggles.mentoring_service.domain;
+
+public enum MentoringType {
+	ONE_ON_ONE,
+	GROUP
+}

--- a/src/main/java/com/goggles/mentoring_service/domain/RepeatPattern.java
+++ b/src/main/java/com/goggles/mentoring_service/domain/RepeatPattern.java
@@ -1,0 +1,29 @@
+package com.goggles.mentoring_service.domain;
+
+import jakarta.persistence.Embeddable;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+import java.time.DayOfWeek;
+import java.time.LocalTime;
+
+@Embeddable
+@Getter
+@ToString
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class RepeatPattern {
+	private DayOfWeek dayOfWeek;
+	private LocalTime startTime;
+	private LocalTime endTime;
+
+
+	public static RepeatPattern of(DayOfWeek dayOfWeek, LocalTime startTime, LocalTime endTime) {
+		RepeatPattern pattern = new RepeatPattern();
+		pattern.dayOfWeek = dayOfWeek;
+		pattern.startTime = startTime;
+		pattern.endTime = endTime;
+		return pattern;
+	}
+}

--- a/src/main/java/com/goggles/mentoring_service/domain/SessionStatus.java
+++ b/src/main/java/com/goggles/mentoring_service/domain/SessionStatus.java
@@ -1,0 +1,7 @@
+package com.goggles.mentoring_service.domain;
+
+public enum SessionStatus {
+	AVAILABLE,
+	BOOKED,
+	NOT_AVAILABLE
+}

--- a/src/main/java/com/goggles/mentoring_service/domain/UserType.java
+++ b/src/main/java/com/goggles/mentoring_service/domain/UserType.java
@@ -1,0 +1,5 @@
+package com.goggles.mentoring_service.domain;
+
+public enum UserType {
+	STUDENT, INSTRUCTOR, MASTER
+}

--- a/src/main/java/com/goggles/mentoring_service/domain/exception/BookedSessionCannotBeDeletedException.java
+++ b/src/main/java/com/goggles/mentoring_service/domain/exception/BookedSessionCannotBeDeletedException.java
@@ -1,0 +1,10 @@
+package com.goggles.mentoring_service.domain.exception;
+
+import com.goggles.common.exception.ConflictException;
+
+public class BookedSessionCannotBeDeletedException extends ConflictException {
+
+	public BookedSessionCannotBeDeletedException() {
+		super("예약된 세션은 삭제할 수 없습니다.");
+	}
+}

--- a/src/main/java/com/goggles/mentoring_service/domain/exception/BookedSessionStatusCannotBeChangedException.java
+++ b/src/main/java/com/goggles/mentoring_service/domain/exception/BookedSessionStatusCannotBeChangedException.java
@@ -1,0 +1,10 @@
+package com.goggles.mentoring_service.domain.exception;
+
+import com.goggles.common.exception.ConflictException;
+
+public class BookedSessionStatusCannotBeChangedException extends ConflictException {
+
+	public BookedSessionStatusCannotBeChangedException() {
+		super("예약된 세션은 상태를 변경할 수 없습니다.");
+	}
+}

--- a/src/main/java/com/goggles/mentoring_service/domain/exception/InactiveCategoryCannotMoveException.java
+++ b/src/main/java/com/goggles/mentoring_service/domain/exception/InactiveCategoryCannotMoveException.java
@@ -1,0 +1,9 @@
+package com.goggles.mentoring_service.domain.exception;
+
+import com.goggles.common.exception.BadRequestException;
+
+public class InactiveCategoryCannotMoveException extends BadRequestException {
+	public InactiveCategoryCannotMoveException() {
+		super("비활성화된 카테고리는 이동할 수 없습니다.");
+	}
+}

--- a/src/main/java/com/goggles/mentoring_service/domain/exception/InactiveCategoryCannotMoveException.java
+++ b/src/main/java/com/goggles/mentoring_service/domain/exception/InactiveCategoryCannotMoveException.java
@@ -1,8 +1,7 @@
 package com.goggles.mentoring_service.domain.exception;
 
-import com.goggles.common.exception.BadRequestException;
 
-public class InactiveCategoryCannotMoveException extends BadRequestException {
+public class InactiveCategoryCannotMoveException extends MentoringValidationException {
 	public InactiveCategoryCannotMoveException() {
 		super("비활성화된 카테고리는 이동할 수 없습니다.");
 	}

--- a/src/main/java/com/goggles/mentoring_service/domain/exception/InvalidMentorUserTypeException.java
+++ b/src/main/java/com/goggles/mentoring_service/domain/exception/InvalidMentorUserTypeException.java
@@ -7,7 +7,6 @@ import java.util.UUID;
 public class InvalidMentorUserTypeException extends MentoringValidationException {
 
 	public InvalidMentorUserTypeException(UUID mentorId, UserType userType) {
-		super(String.format("멘토는 INSTRUCTOR 타입이어야 합니다. USER ID: %s, USER_TYPE: %s", mentorId, userType.name()));
-
+		super(String.format("멘토는 INSTRUCTOR 타입이어야 합니다. USER_TYPE: %s", String.valueOf(userType)));
 	}
 }

--- a/src/main/java/com/goggles/mentoring_service/domain/exception/InvalidMentorUserTypeException.java
+++ b/src/main/java/com/goggles/mentoring_service/domain/exception/InvalidMentorUserTypeException.java
@@ -1,13 +1,13 @@
 package com.goggles.mentoring_service.domain.exception;
 
-import com.goggles.common.exception.BadRequestException;
 import com.goggles.mentoring_service.domain.UserType;
 
 import java.util.UUID;
 
-public class InvalidMentorUserTypeException extends BadRequestException {
+public class InvalidMentorUserTypeException extends MentoringValidationException {
 
 	public InvalidMentorUserTypeException(UUID mentorId, UserType userType) {
-		super("멘토는 INSTRUCTOR 타입이어야 합니다. USER ID:{} USER_TYPE: {}" + mentorId, userType.name());
+		super(String.format("멘토는 INSTRUCTOR 타입이어야 합니다. USER ID: %s, USER_TYPE: %s", mentorId, userType.name()));
+
 	}
 }

--- a/src/main/java/com/goggles/mentoring_service/domain/exception/InvalidMentorUserTypeException.java
+++ b/src/main/java/com/goggles/mentoring_service/domain/exception/InvalidMentorUserTypeException.java
@@ -1,0 +1,13 @@
+package com.goggles.mentoring_service.domain.exception;
+
+import com.goggles.common.exception.BadRequestException;
+import com.goggles.mentoring_service.domain.UserType;
+
+import java.util.UUID;
+
+public class InvalidMentorUserTypeException extends BadRequestException {
+
+	public InvalidMentorUserTypeException(UUID mentorId, UserType userType) {
+		super("멘토는 INSTRUCTOR 타입이어야 합니다. USER ID:{} USER_TYPE: {}" + mentorId, userType.name());
+	}
+}

--- a/src/main/java/com/goggles/mentoring_service/domain/exception/InvalidMentoringCategoryAdminUserTypeException.java
+++ b/src/main/java/com/goggles/mentoring_service/domain/exception/InvalidMentoringCategoryAdminUserTypeException.java
@@ -1,0 +1,12 @@
+package com.goggles.mentoring_service.domain.exception;
+
+import com.goggles.common.exception.ForbiddenException;
+import com.goggles.mentoring_service.domain.UserType;
+
+import java.util.UUID;
+
+public class InvalidMentoringCategoryAdminUserTypeException extends ForbiddenException {
+	public InvalidMentoringCategoryAdminUserTypeException(UUID userId, UserType userType) {
+		super(String.format("권한이 없는 사용자입니다 USER ID: %s, USER_TYPE: %s", userId, userType.name()));
+	}
+}

--- a/src/main/java/com/goggles/mentoring_service/domain/exception/InvalidMentoringCategoryAdminUserTypeException.java
+++ b/src/main/java/com/goggles/mentoring_service/domain/exception/InvalidMentoringCategoryAdminUserTypeException.java
@@ -7,6 +7,6 @@ import java.util.UUID;
 
 public class InvalidMentoringCategoryAdminUserTypeException extends ForbiddenException {
 	public InvalidMentoringCategoryAdminUserTypeException(UUID userId, UserType userType) {
-		super(String.format("권한이 없는 사용자입니다 USER ID: %s, USER_TYPE: %s", userId, userType.name()));
+		super(String.format("권한이 없는 사용자입니다. USER_TYPE: %s", String.valueOf(userType)));
 	}
 }

--- a/src/main/java/com/goggles/mentoring_service/domain/exception/InvalidMentoringPolicyException.java
+++ b/src/main/java/com/goggles/mentoring_service/domain/exception/InvalidMentoringPolicyException.java
@@ -1,8 +1,7 @@
 package com.goggles.mentoring_service.domain.exception;
 
-import com.goggles.common.exception.BadRequestException;
 
-public class InvalidMentoringPolicyException extends BadRequestException {
+public class InvalidMentoringPolicyException extends MentoringValidationException {
 
 	public InvalidMentoringPolicyException(String message) {
 		super(message);

--- a/src/main/java/com/goggles/mentoring_service/domain/exception/InvalidMentoringPolicyException.java
+++ b/src/main/java/com/goggles/mentoring_service/domain/exception/InvalidMentoringPolicyException.java
@@ -1,0 +1,11 @@
+package com.goggles.mentoring_service.domain.exception;
+
+import com.goggles.common.exception.BadRequestException;
+
+public class InvalidMentoringPolicyException extends BadRequestException {
+
+	public InvalidMentoringPolicyException(String message) {
+		super(message);
+	}
+}
+

--- a/src/main/java/com/goggles/mentoring_service/domain/exception/MentoringDomainException.java
+++ b/src/main/java/com/goggles/mentoring_service/domain/exception/MentoringDomainException.java
@@ -1,0 +1,8 @@
+package com.goggles.mentoring_service.domain.exception;
+
+public abstract class MentoringDomainException extends RuntimeException {
+
+	protected MentoringDomainException(String message) {
+		super(message);
+	}
+}

--- a/src/main/java/com/goggles/mentoring_service/domain/exception/MentoringValidationException.java
+++ b/src/main/java/com/goggles/mentoring_service/domain/exception/MentoringValidationException.java
@@ -1,0 +1,8 @@
+package com.goggles.mentoring_service.domain.exception;
+
+public class MentoringValidationException extends MentoringDomainException {
+
+	public MentoringValidationException(String message) {
+		super(message);
+	}
+}

--- a/src/main/java/com/goggles/mentoring_service/domain/exception/RepeatPatternRequiredException.java
+++ b/src/main/java/com/goggles/mentoring_service/domain/exception/RepeatPatternRequiredException.java
@@ -1,8 +1,6 @@
 package com.goggles.mentoring_service.domain.exception;
 
-import com.goggles.common.exception.BadRequestException;
-
-public class RepeatPatternRequiredException extends BadRequestException {
+public class RepeatPatternRequiredException extends MentoringValidationException {
 
 	public RepeatPatternRequiredException() {
 		super("자동 반복 멘토링은 요일 반복 패턴이 설정되어야 활성화할 수 있습니다.");

--- a/src/main/java/com/goggles/mentoring_service/domain/exception/RepeatPatternRequiredException.java
+++ b/src/main/java/com/goggles/mentoring_service/domain/exception/RepeatPatternRequiredException.java
@@ -1,0 +1,10 @@
+package com.goggles.mentoring_service.domain.exception;
+
+import com.goggles.common.exception.BadRequestException;
+
+public class RepeatPatternRequiredException extends BadRequestException {
+
+	public RepeatPatternRequiredException() {
+		super("자동 반복 멘토링은 요일 반복 패턴이 설정되어야 활성화할 수 있습니다.");
+	}
+}

--- a/src/main/java/com/goggles/mentoring_service/domain/exception/SessionNotAvailableException.java
+++ b/src/main/java/com/goggles/mentoring_service/domain/exception/SessionNotAvailableException.java
@@ -1,0 +1,10 @@
+package com.goggles.mentoring_service.domain.exception;
+
+import com.goggles.common.exception.ConflictException;
+
+public class SessionNotAvailableException extends ConflictException {
+
+	public SessionNotAvailableException() {
+		super("예약 가능한 세션이 아닙니다.");
+	}
+}

--- a/src/main/java/com/goggles/mentoring_service/domain/exception/SessionNotFoundException.java
+++ b/src/main/java/com/goggles/mentoring_service/domain/exception/SessionNotFoundException.java
@@ -1,0 +1,13 @@
+package com.goggles.mentoring_service.domain.exception;
+
+import com.goggles.common.exception.NotFoundException;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+
+public class SessionNotFoundException extends NotFoundException {
+
+	public SessionNotFoundException(LocalDate date, LocalTime startTime) {
+		super(date + " " + startTime + "에 해당하는 세션이 존재하지 않습니다.");
+	}
+}

--- a/src/main/java/com/goggles/mentoring_service/presentation/MentoringExceptionHandler.java
+++ b/src/main/java/com/goggles/mentoring_service/presentation/MentoringExceptionHandler.java
@@ -1,0 +1,20 @@
+package com.goggles.mentoring_service.presentation;
+
+
+import com.goggles.mentoring_service.domain.exception.MentoringValidationException;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ProblemDetail;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+public class MentoringExceptionHandler {
+
+	@ExceptionHandler(MentoringValidationException.class)
+	public ProblemDetail handleValidationException(MentoringValidationException e) {
+		ProblemDetail problemDetail = ProblemDetail.forStatus(HttpStatus.BAD_REQUEST);
+		problemDetail.setTitle("Invalid mentoring request");
+		problemDetail.setDetail(e.getMessage());
+		return problemDetail;
+	}
+}

--- a/src/main/java/com/goggles/mentoring_service/presentation/MentoringExceptionHandler.java
+++ b/src/main/java/com/goggles/mentoring_service/presentation/MentoringExceptionHandler.java
@@ -1,6 +1,9 @@
 package com.goggles.mentoring_service.presentation;
 
 
+import com.goggles.common.exception.ConflictException;
+import com.goggles.common.exception.ForbiddenException;
+import com.goggles.common.exception.NotFoundException;
 import com.goggles.mentoring_service.domain.exception.MentoringValidationException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ProblemDetail;
@@ -14,6 +17,30 @@ public class MentoringExceptionHandler {
 	public ProblemDetail handleValidationException(MentoringValidationException e) {
 		ProblemDetail problemDetail = ProblemDetail.forStatus(HttpStatus.BAD_REQUEST);
 		problemDetail.setTitle("Invalid mentoring request");
+		problemDetail.setDetail(e.getMessage());
+		return problemDetail;
+	}
+
+	@ExceptionHandler(ConflictException.class)
+	public ProblemDetail handleConflictException(ConflictException e) {
+		ProblemDetail problemDetail = ProblemDetail.forStatus(HttpStatus.CONFLICT);
+		problemDetail.setTitle("Conflict");
+		problemDetail.setDetail(e.getMessage());
+		return problemDetail;
+	}
+
+	@ExceptionHandler(ForbiddenException.class)
+	public ProblemDetail handleForbiddenException(ForbiddenException e) {
+		ProblemDetail problemDetail = ProblemDetail.forStatus(HttpStatus.FORBIDDEN);
+		problemDetail.setTitle("Forbidden");
+		problemDetail.setDetail("접근 권한이 없습니다.");
+		return problemDetail;
+	}
+
+	@ExceptionHandler(NotFoundException.class)
+	public ProblemDetail handleNotFoundException(NotFoundException e) {
+		ProblemDetail problemDetail = ProblemDetail.forStatus(HttpStatus.NOT_FOUND);
+		problemDetail.setTitle("Not Found");
 		problemDetail.setDetail(e.getMessage());
 		return problemDetail;
 	}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -1,6 +1,6 @@
 spring:
   application:
-    name: mentoring-server
+    name: mentoring-service
   datasource:
     url: jdbc:postgresql://localhost:5432/goggles
     username: ${DB_USERNAME:goggles}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -66,6 +66,9 @@ spring:
     activate:
       on-profile: local
 
+  jpa:
+    hibernate:
+      ddl-auto: create
 management:
   tracing:
     sampling:

--- a/src/test/java/com/goggles/mentoring_service/MentoringServerApplicationTests.java
+++ b/src/test/java/com/goggles/mentoring_service/MentoringServerApplicationTests.java
@@ -1,4 +1,4 @@
-package com.goggles.mentoring_server;
+package com.goggles.mentoring_service;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;


### PR DESCRIPTION
### 📌 관련 이슈
-  #2 

### 💡 작업 내용
- 멘토링 서비스 모듈 이름 변경 (mentoring-server → mentoring-service)                                      
  - MentoringCategory 도메인 모델링 및 CRUD 정책 구현 (활성/비활성, 순서 이동, soft delete)                  
  - Mentoring 애그리거트 루트 모델링                                                                         
    - 예약 유형(BookingType): 단건 / 자유 선택 / 자동 반복                                                   
    - 멘토링 유형(MentoringType): 1:1 / 그룹                                                                 
    - 반복 패턴(RepeatPattern), 세션 목록(MentoringSession) 관리                                             
    - 생성 시 타입 조합 유효성 검증 (그룹 최소 인원, SELF_SELECT 최소 세션 수 등)                            
  - MentoringSession 임베더블 구현 (AVAILABLE / BOOKED / NOT_AVAILABLE 상태 전이 및 예약 처리)               
  - Mentor 임베더블 구현 (강사만 멘토 등록 가능하도록 검증)                                       
  - 도메인 예외 클래스 정리 

### 🔍 변경 이유
  - 멘토링 도메인의 핵심 모델(애그리거트, 값 객체, 열거형)을 먼저 정의하여 이후 예약 및 세션 기능 구현의     
  기반을 마련하기 위해   

### 📝 리뷰 포인트 
- 도메인 구성에서 도메인의 역할이 잘 드러나는 가 

### 🧠 기타 참고 사항
- 코드 량이 너무 많아져 다음 멘토링 예약(Booking) 부분은 별도 PR 로 분리 합니다. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 멘토링 생성, 활성화/비활성화 및 상세 관리 기능 추가
  * 세션 생성·업데이트·삭제, 예약(booking) 및 세션 활성화/비활성화 기능 추가
  * 멘토링 카테고리 생성·수정·정렬·활성화 관리 기능 추가
  * 반복 패턴 기반 자동 반복 예약 및 다양한 예약 유형 지원
  * API 예외를 통일된 문제 응답(ProblemDetail)으로 반환하는 중앙 핸들링 추가

* **기타**
  * 프로젝트 명칭 및 설정 업데이트(서비스 이름 변경)
  * 로컬 개발용 README 및 패키지 인증 안내 추가
  * 빌드 구성과 외부 공용 라이브러리 연동 설정 추가
<!-- end of auto-generated comment: release notes by coderabbit.ai -->