### PR TITLE
[FEAT] 멘토링 생성 API

### DIFF
--- a/src/main/java/com/goggles/mentoring_service/application/command/MentoringCommand.java
+++ b/src/main/java/com/goggles/mentoring_service/application/command/MentoringCommand.java
@@ -1,0 +1,60 @@
+package com.goggles.mentoring_service.application.command;
+
+import com.goggles.mentoring_service.domain.category.MentoringCategory;
+import com.goggles.mentoring_service.domain.common.UserType;
+import com.goggles.mentoring_service.domain.mentoring.BookingType;
+import com.goggles.mentoring_service.domain.mentoring.Mentoring;
+import com.goggles.mentoring_service.domain.mentoring.MentoringDuration;
+import com.goggles.mentoring_service.domain.mentoring.MentoringStatus;
+import com.goggles.mentoring_service.domain.mentoring.MentoringType;
+
+import java.time.LocalDate;
+import java.util.UUID;
+
+public class MentoringCommand {
+
+	public record Create(
+			UUID mentorId,
+			String mentorName,
+			String mentorField,
+			String mentorEmail,
+			UserType mentorType,
+			UUID categoryId,
+			String title,
+			String subtitle,
+			String description,
+			MentoringDuration duration,
+			MentoringType mentoringType,
+			BookingType bookingType,
+			int sessionCount,
+			int maxParticipants,
+			boolean excludeHolidays,
+			int price,
+			LocalDate endDate
+	) {
+		public Mentoring toMentoring(MentoringCategory category) {
+			return Mentoring.builder()
+					.mentorId(mentorId())
+					.mentorName(mentorName())
+					.mentorField(mentorField())
+					.mentorEmail(mentorEmail())
+					.mentorType(mentorType())
+					.categoryId(category.getMentoringCategoryId().categoryId())
+					.categoryName(category.getName())
+					.categoryCode(category.getCode())
+					.title(title())
+					.subtitle(subtitle())
+					.description(description())
+					.duration(duration())
+					.status(MentoringStatus.INACTIVE)
+					.mentoringType(mentoringType())
+					.bookingType(bookingType())
+					.sessionCount(sessionCount())
+					.maxParticipants(maxParticipants())
+					.excludeHolidays(excludeHolidays())
+					.price(price())
+					.endDate(endDate())
+					.build();
+		}
+	}
+}

--- a/src/main/java/com/goggles/mentoring_service/application/command/MentoringCommand.java
+++ b/src/main/java/com/goggles/mentoring_service/application/command/MentoringCommand.java
@@ -2,44 +2,37 @@ package com.goggles.mentoring_service.application.command;
 
 import com.goggles.mentoring_service.domain.category.MentoringCategory;
 import com.goggles.mentoring_service.domain.common.UserType;
-import com.goggles.mentoring_service.domain.mentoring.BookingType;
-import com.goggles.mentoring_service.domain.mentoring.Mentoring;
-import com.goggles.mentoring_service.domain.mentoring.MentoringDuration;
-import com.goggles.mentoring_service.domain.mentoring.MentoringStatus;
-import com.goggles.mentoring_service.domain.mentoring.MentoringType;
+import com.goggles.mentoring_service.domain.mentoring.*;
 
 import java.time.LocalDate;
+import java.util.List;
 import java.util.UUID;
 
 public class MentoringCommand {
 
-	public record Create(
-			UUID mentorId,
-			String mentorName,
-			String mentorField,
-			String mentorEmail,
-			UserType mentorType,
-			UUID categoryId,
-			String title,
-			String subtitle,
-			String description,
-			MentoringDuration duration,
-			MentoringType mentoringType,
-			BookingType bookingType,
-			int sessionCount,
-			int maxParticipants,
-			boolean excludeHolidays,
-			int price,
-			LocalDate endDate
-	) {
+	public record Create(UUID mentorId, String mentorName, String mentorField, String mentorEmail,
+						 UserType mentorType, UUID categoryId, String title, String subtitle,
+						 String description, MentoringDuration duration,
+						 MentoringType mentoringType, Format format, int sessionCount,
+						 int maxParticipants, boolean excludeHolidays, int price, LocalDate endDate,
+						 List<SessionSlot> sessionSlots, List<TimeSchedules> timeSchedules) {
 		public Mentoring toMentoring(MentoringCategory category) {
+			List<RepeatPattern> repeatPatterns = timeSchedules().stream()
+					.map(timeSchedules -> RepeatPattern.of(timeSchedules.dayOfWeek(),
+							timeSchedules.startTime(), timeSchedules.endTime()))
+					.toList();
+			List<MentoringSession> sessions = sessionSlots().stream()
+					.map(sessionSlot -> MentoringSession.of(sessionSlot.date(),
+							sessionSlot.startTime(), sessionSlot.endTime()))
+					.toList();
 			return Mentoring.builder()
 					.mentorId(mentorId())
 					.mentorName(mentorName())
 					.mentorField(mentorField())
 					.mentorEmail(mentorEmail())
 					.mentorType(mentorType())
-					.categoryId(category.getMentoringCategoryId().categoryId())
+					.categoryId(category.getMentoringCategoryId()
+							.categoryId())
 					.categoryName(category.getName())
 					.categoryCode(category.getCode())
 					.title(title())
@@ -48,13 +41,17 @@ public class MentoringCommand {
 					.duration(duration())
 					.status(MentoringStatus.INACTIVE)
 					.mentoringType(mentoringType())
-					.bookingType(bookingType())
+					.format(format())
 					.sessionCount(sessionCount())
 					.maxParticipants(maxParticipants())
 					.excludeHolidays(excludeHolidays())
 					.price(price())
 					.endDate(endDate())
+					.repeatPatterns(repeatPatterns)
+					.sessions(sessions)
 					.build();
 		}
 	}
+
+
 }

--- a/src/main/java/com/goggles/mentoring_service/application/command/SessionSlot.java
+++ b/src/main/java/com/goggles/mentoring_service/application/command/SessionSlot.java
@@ -1,0 +1,6 @@
+package com.goggles.mentoring_service.application.command;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+
+public record SessionSlot(LocalDate date, LocalTime startTime, LocalTime endTime) {}

--- a/src/main/java/com/goggles/mentoring_service/application/command/TimeSchedules.java
+++ b/src/main/java/com/goggles/mentoring_service/application/command/TimeSchedules.java
@@ -1,0 +1,7 @@
+package com.goggles.mentoring_service.application.command;
+
+
+import java.time.DayOfWeek;
+import java.time.LocalTime;
+
+public record TimeSchedules(DayOfWeek dayOfWeek, LocalTime startTime, LocalTime endTime) {}

--- a/src/main/java/com/goggles/mentoring_service/application/service/MentoringService.java
+++ b/src/main/java/com/goggles/mentoring_service/application/service/MentoringService.java
@@ -1,0 +1,33 @@
+package com.goggles.mentoring_service.application.service;
+
+import com.goggles.mentoring_service.application.command.MentoringCommand;
+import com.goggles.mentoring_service.domain.category.MentoringCategory;
+import com.goggles.mentoring_service.domain.category.MentoringCategoryId;
+import com.goggles.mentoring_service.domain.category.exception.CategoryNotFoundException;
+import com.goggles.mentoring_service.domain.category.repository.MentoringCategoryRepository;
+import com.goggles.mentoring_service.domain.mentoring.Mentoring;
+import com.goggles.mentoring_service.domain.mentoring.repository.MentoringRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class MentoringService {
+
+	private final MentoringRepository mentoringRepository;
+	private final MentoringCategoryRepository categoryRepository;
+
+	public UUID createMentoring(MentoringCommand.Create command) {
+		UUID categoryId = command.categoryId();
+		MentoringCategory category = categoryRepository.findById(new MentoringCategoryId(categoryId))
+				.orElseThrow(() -> new CategoryNotFoundException(categoryId));
+
+		Mentoring mentoring = command.toMentoring(category);
+		mentoringRepository.save(mentoring);
+		return mentoring.getMentoringId().mentoringId();
+	}
+}

--- a/src/main/java/com/goggles/mentoring_service/application/service/MentoringService.java
+++ b/src/main/java/com/goggles/mentoring_service/application/service/MentoringService.java
@@ -23,11 +23,14 @@ public class MentoringService {
 
 	public UUID createMentoring(MentoringCommand.Create command) {
 		UUID categoryId = command.categoryId();
-		MentoringCategory category = categoryRepository.findById(new MentoringCategoryId(categoryId))
-				.orElseThrow(() -> new CategoryNotFoundException(categoryId));
+		MentoringCategory category =
+				categoryRepository.findById(new MentoringCategoryId(categoryId))
+						.orElseThrow(() -> new CategoryNotFoundException(categoryId));
 
 		Mentoring mentoring = command.toMentoring(category);
+
 		mentoringRepository.save(mentoring);
-		return mentoring.getMentoringId().mentoringId();
+		return mentoring.getMentoringId()
+				.mentoringId();
 	}
 }

--- a/src/main/java/com/goggles/mentoring_service/domain/booking/BookedMentoring.java
+++ b/src/main/java/com/goggles/mentoring_service/domain/booking/BookedMentoring.java
@@ -37,8 +37,8 @@ public class BookedMentoring {
 
 
 	static BookedMentoring of(UUID mentoringId, String categoryCode, String categoryName,
-			String title, String subtitle, UUID mentorId, String mentorName,
-			LocalDate sessionDate, LocalTime sessionStartTime, LocalTime sessionEndTime) {
+			String title, String subtitle, UUID mentorId, String mentorName, LocalDate sessionDate,
+			LocalTime sessionStartTime, LocalTime sessionEndTime) {
 		BookedMentoring bookedMentoring = new BookedMentoring();
 		bookedMentoring.mentoringId = mentoringId;
 		bookedMentoring.categoryCode = categoryCode;

--- a/src/main/java/com/goggles/mentoring_service/domain/booking/BookingStatus.java
+++ b/src/main/java/com/goggles/mentoring_service/domain/booking/BookingStatus.java
@@ -22,7 +22,8 @@ public enum BookingStatus {
 				throw InvalidBookingStatusTransitionException.cannotModifyPaymentFailed();
 			}
 			throw switch (newStatus) {
-				case PAYMENT_COMPLETED -> InvalidBookingStatusTransitionException.cannotCompletePayment(this);
+				case PAYMENT_COMPLETED ->
+						InvalidBookingStatusTransitionException.cannotCompletePayment(this);
 				case ACCEPTED -> InvalidBookingStatusTransitionException.cannotAccept(this);
 				case REJECTED -> InvalidBookingStatusTransitionException.cannotReject(this);
 				case CANCELED -> InvalidBookingStatusTransitionException.alreadyClosedBooking(this);

--- a/src/main/java/com/goggles/mentoring_service/domain/booking/Mentee.java
+++ b/src/main/java/com/goggles/mentoring_service/domain/booking/Mentee.java
@@ -1,7 +1,7 @@
 package com.goggles.mentoring_service.domain.booking;
 
-import com.goggles.mentoring_service.domain.common.UserType;
 import com.goggles.mentoring_service.domain.booking.exception.InvalidMenteeUserTypeException;
+import com.goggles.mentoring_service.domain.common.UserType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Embeddable;
 import lombok.AccessLevel;

--- a/src/main/java/com/goggles/mentoring_service/domain/booking/MentoringBooking.java
+++ b/src/main/java/com/goggles/mentoring_service/domain/booking/MentoringBooking.java
@@ -50,14 +50,13 @@ public class MentoringBooking extends BaseAudit {
 	}
 
 	@Builder
-	public static MentoringBooking create(
-			UUID mentoringId, String categoryCode, String categoryName,
-			String title, String subtitle, UUID mentorId, String mentorName,
+	public static MentoringBooking create(UUID mentoringId, String categoryCode,
+			String categoryName, String title, String subtitle, UUID mentorId, String mentorName,
 			LocalDate sessionDate, LocalTime sessionStartTime, LocalTime sessionEndTime,
 			UUID menteeId, UserType menteeUserType, String menteeName) {
-		BookedMentoring bookedMentoring = BookedMentoring.of(
-				mentoringId, categoryCode, categoryName, title, subtitle,
-				mentorId, mentorName, sessionDate, sessionStartTime, sessionEndTime);
+		BookedMentoring bookedMentoring =
+				BookedMentoring.of(mentoringId, categoryCode, categoryName, title, subtitle,
+						mentorId, mentorName, sessionDate, sessionStartTime, sessionEndTime);
 		Mentee mentee = Mentee.of(menteeId, menteeUserType, menteeName);
 		return new MentoringBooking(bookedMentoring, mentee);
 	}
@@ -118,11 +117,13 @@ public class MentoringBooking extends BaseAudit {
 			if (!bookedMentoring.isMentor(canceledBy)) {
 				throw UnauthorizedBookingAccessException.noPermissionToCancel();
 			}
-		} else if (userType == UserType.STUDENT) {
+		}
+		else if (userType == UserType.STUDENT) {
 			if (!mentee.isMentee(canceledBy)) {
 				throw UnauthorizedBookingAccessException.noPermissionToCancel();
 			}
-		} else {
+		}
+		else {
 			throw UnauthorizedBookingAccessException.noPermissionToCancel();
 		}
 	}

--- a/src/main/java/com/goggles/mentoring_service/domain/booking/event/BookingAcceptedEvent.java
+++ b/src/main/java/com/goggles/mentoring_service/domain/booking/event/BookingAcceptedEvent.java
@@ -4,14 +4,6 @@ import java.time.LocalDate;
 import java.time.LocalTime;
 import java.util.UUID;
 
-public record BookingAcceptedEvent(
-		UUID bookingId,
-		UUID menteeId,
-		UUID mentorId,
-		String mentorName,
-		String title,
-		LocalDate sessionDate,
-		LocalTime sessionStartTime,
-		LocalTime sessionEndTime
-) {
-}
+public record BookingAcceptedEvent(UUID bookingId, UUID menteeId, UUID mentorId, String mentorName,
+								   String title, LocalDate sessionDate, LocalTime sessionStartTime,
+								   LocalTime sessionEndTime) {}

--- a/src/main/java/com/goggles/mentoring_service/domain/booking/event/BookingCanceledEvent.java
+++ b/src/main/java/com/goggles/mentoring_service/domain/booking/event/BookingCanceledEvent.java
@@ -3,13 +3,5 @@ package com.goggles.mentoring_service.domain.booking.event;
 import java.time.LocalDate;
 import java.util.UUID;
 
-public record BookingCanceledEvent(
-		UUID bookingId,
-		UUID canceledBy,
-		UUID menteeId,
-		UUID mentorId,
-		String title,
-		String reason,
-		LocalDate sessionDate
-) {
-}
+public record BookingCanceledEvent(UUID bookingId, UUID canceledBy, UUID menteeId, UUID mentorId,
+								   String title, String reason, LocalDate sessionDate) {}

--- a/src/main/java/com/goggles/mentoring_service/domain/booking/event/BookingPendingApprovalEvent.java
+++ b/src/main/java/com/goggles/mentoring_service/domain/booking/event/BookingPendingApprovalEvent.java
@@ -4,13 +4,6 @@ import java.time.LocalDate;
 import java.time.LocalTime;
 import java.util.UUID;
 
-public record BookingPendingApprovalEvent(
-		UUID bookingId,
-		UUID mentorId,
-		String menteeName,
-		String title,
-		LocalDate sessionDate,
-		LocalTime sessionStartTime,
-		LocalTime sessionEndTime
-) {
-}
+public record BookingPendingApprovalEvent(UUID bookingId, UUID mentorId, String menteeName,
+										  String title, LocalDate sessionDate,
+										  LocalTime sessionStartTime, LocalTime sessionEndTime) {}

--- a/src/main/java/com/goggles/mentoring_service/domain/booking/event/BookingRejectedEvent.java
+++ b/src/main/java/com/goggles/mentoring_service/domain/booking/event/BookingRejectedEvent.java
@@ -3,13 +3,5 @@ package com.goggles.mentoring_service.domain.booking.event;
 import java.time.LocalDate;
 import java.util.UUID;
 
-public record BookingRejectedEvent(
-		UUID bookingId,
-		UUID menteeId,
-		UUID mentorId,
-		String mentorName,
-		String title,
-		String reason,
-		LocalDate sessionDate
-) {
-}
+public record BookingRejectedEvent(UUID bookingId, UUID menteeId, UUID mentorId, String mentorName,
+								   String title, String reason, LocalDate sessionDate) {}

--- a/src/main/java/com/goggles/mentoring_service/domain/booking/event/BookingRequestedEvent.java
+++ b/src/main/java/com/goggles/mentoring_service/domain/booking/event/BookingRequestedEvent.java
@@ -5,14 +5,6 @@ import java.time.LocalTime;
 import java.util.UUID;
 
 // TODO: 주문 서비스와 페이로드 협의 후 확정
-public record BookingRequestedEvent(
-		UUID bookingId,
-		UUID mentoringId,
-		UUID menteeId,
-		UUID mentorId,
-		String title,
-		LocalDate sessionDate,
-		LocalTime sessionStartTime,
-		LocalTime sessionEndTime
-) {
-}
+public record BookingRequestedEvent(UUID bookingId, UUID mentoringId, UUID menteeId, UUID mentorId,
+									String title, LocalDate sessionDate, LocalTime sessionStartTime,
+									LocalTime sessionEndTime) {}

--- a/src/main/java/com/goggles/mentoring_service/domain/booking/event/PaymentCompletedEvent.java
+++ b/src/main/java/com/goggles/mentoring_service/domain/booking/event/PaymentCompletedEvent.java
@@ -2,7 +2,4 @@ package com.goggles.mentoring_service.domain.booking.event;
 
 import java.util.UUID;
 
-public record PaymentCompletedEvent(
-		UUID bookingId
-) {
-}
+public record PaymentCompletedEvent(UUID bookingId) {}

--- a/src/main/java/com/goggles/mentoring_service/domain/booking/event/PaymentFailedEvent.java
+++ b/src/main/java/com/goggles/mentoring_service/domain/booking/event/PaymentFailedEvent.java
@@ -2,7 +2,4 @@ package com.goggles.mentoring_service.domain.booking.event;
 
 import java.util.UUID;
 
-public record PaymentFailedEvent(
-		UUID bookingId
-) {
-}
+public record PaymentFailedEvent(UUID bookingId) {}

--- a/src/main/java/com/goggles/mentoring_service/domain/booking/exception/InvalidBookingStatusTransitionException.java
+++ b/src/main/java/com/goggles/mentoring_service/domain/booking/exception/InvalidBookingStatusTransitionException.java
@@ -9,7 +9,8 @@ public class InvalidBookingStatusTransitionException extends MentoringValidation
 		super(message);
 	}
 
-	public static InvalidBookingStatusTransitionException cannotCompletePayment(BookingStatus current) {
+	public static InvalidBookingStatusTransitionException cannotCompletePayment(
+			BookingStatus current) {
 		return new InvalidBookingStatusTransitionException(
 				String.format("결제 완료 처리는 PENDING 상태에서만 가능합니다. 현재 상태: %s", current));
 	}
@@ -28,7 +29,8 @@ public class InvalidBookingStatusTransitionException extends MentoringValidation
 				String.format("예약 거절은 PAYMENT_COMPLETED 상태에서만 가능합니다. 현재 상태: %s", current));
 	}
 
-	public static InvalidBookingStatusTransitionException alreadyClosedBooking(BookingStatus current) {
+	public static InvalidBookingStatusTransitionException alreadyClosedBooking(
+			BookingStatus current) {
 		return new InvalidBookingStatusTransitionException(
 				String.format("이미 종료된 예약은 변경할 수 없습니다. 현재 상태: %s", current));
 	}

--- a/src/main/java/com/goggles/mentoring_service/domain/booking/exception/InvalidMenteeUserTypeException.java
+++ b/src/main/java/com/goggles/mentoring_service/domain/booking/exception/InvalidMenteeUserTypeException.java
@@ -8,7 +8,7 @@ import java.util.UUID;
 public class InvalidMenteeUserTypeException extends MentoringValidationException {
 
 	public InvalidMenteeUserTypeException(UUID menteeId, UserType userType) {
-		super(String.format("멘티는 STUDENT 타입이어야 합니다. USER_ID : %s USER_TYPE: %s",menteeId,
+		super(String.format("멘티는 STUDENT 타입이어야 합니다. USER_ID : %s USER_TYPE: %s", menteeId,
 				userType));
 	}
 }

--- a/src/main/java/com/goggles/mentoring_service/domain/category/exception/CategoryNotFoundException.java
+++ b/src/main/java/com/goggles/mentoring_service/domain/category/exception/CategoryNotFoundException.java
@@ -1,0 +1,12 @@
+package com.goggles.mentoring_service.domain.category.exception;
+
+import com.goggles.common.exception.NotFoundException;
+
+import java.util.UUID;
+
+public class CategoryNotFoundException extends NotFoundException {
+
+	public CategoryNotFoundException(UUID categoryId) {
+		super(String.format("카테고리를 찾을 수 없습니다. ID: %s", categoryId));
+	}
+}

--- a/src/main/java/com/goggles/mentoring_service/domain/mentoring/BookingType.java
+++ b/src/main/java/com/goggles/mentoring_service/domain/mentoring/BookingType.java
@@ -1,5 +1,0 @@
-package com.goggles.mentoring_service.domain.mentoring;
-
-public enum BookingType {
-	ONE_TIME, SELF_SELECT, AUTO_REPEAT
-}

--- a/src/main/java/com/goggles/mentoring_service/domain/mentoring/Format.java
+++ b/src/main/java/com/goggles/mentoring_service/domain/mentoring/Format.java
@@ -1,0 +1,7 @@
+package com.goggles.mentoring_service.domain.mentoring;
+
+public enum Format {
+	SINGLE, // 일회성 예약
+	MULTI // 다회성 예약
+
+}

--- a/src/main/java/com/goggles/mentoring_service/domain/mentoring/HolidayProvider.java
+++ b/src/main/java/com/goggles/mentoring_service/domain/mentoring/HolidayProvider.java
@@ -1,0 +1,7 @@
+package com.goggles.mentoring_service.domain.mentoring;
+
+import java.time.LocalDate;
+
+public interface HolidayProvider {
+    boolean isHoliday(LocalDate date);
+}

--- a/src/main/java/com/goggles/mentoring_service/domain/mentoring/HolidayProvider.java
+++ b/src/main/java/com/goggles/mentoring_service/domain/mentoring/HolidayProvider.java
@@ -3,5 +3,5 @@ package com.goggles.mentoring_service.domain.mentoring;
 import java.time.LocalDate;
 
 public interface HolidayProvider {
-    boolean isHoliday(LocalDate date);
+	boolean isHoliday(LocalDate date);
 }

--- a/src/main/java/com/goggles/mentoring_service/domain/mentoring/Mentor.java
+++ b/src/main/java/com/goggles/mentoring_service/domain/mentoring/Mentor.java
@@ -29,6 +29,7 @@ public class Mentor {
 	@Column(name = "mentor_field", length = 100, nullable = false)
 	private String field;
 
+	@Column(name = "mentor_email", length = 100, nullable = false)
 	private String email;
 
 	@Builder

--- a/src/main/java/com/goggles/mentoring_service/domain/mentoring/Mentoring.java
+++ b/src/main/java/com/goggles/mentoring_service/domain/mentoring/Mentoring.java
@@ -73,7 +73,7 @@ public class Mentoring extends BaseAudit {
 
 	private LocalDate endDate;
 
-	private boolean excludeHolidays;
+	private boolean excludeHolidays = true;
 
 	@Column(nullable = false)
 	private int price;

--- a/src/main/java/com/goggles/mentoring_service/domain/mentoring/Mentoring.java
+++ b/src/main/java/com/goggles/mentoring_service/domain/mentoring/Mentoring.java
@@ -17,6 +17,7 @@ import java.time.Duration;
 import java.time.LocalDate;
 import java.time.LocalTime;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.UUID;
 
@@ -29,33 +30,51 @@ import java.util.UUID;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Mentoring extends BaseAudit {
 
+	@Getter(AccessLevel.NONE)
 	@ElementCollection(fetch = FetchType.LAZY)
 	@CollectionTable(name = "P_REPEAT_PATTERN", joinColumns = @JoinColumn(name = "mentoring_id"))
 	@OrderColumn(name = "pattern_order")
 	private final List<RepeatPattern> repeatPatterns = new ArrayList<>();
+
+	@Getter(AccessLevel.NONE)
 	@ElementCollection(fetch = FetchType.LAZY)
 	@CollectionTable(name = "P_MENTORING_SESSION", joinColumns = @JoinColumn(name = "mentoring_id"))
 	@OrderColumn(name = "session_order")
 	private final List<MentoringSession> sessions = new ArrayList<>();
+
 	@EmbeddedId
 	private MentoringId mentoringId;
+
 	@Embedded
 	private Mentor mentor;
+
 	@Embedded
 	private Category mentoringCategory;
+
 	@Column(length = 100, nullable = false)
 	private String title;
+
 	private String subtitle;
+
 	@Column(columnDefinition = "TEXT")
 	private String description;
+
 	private MentoringDuration duration;
+
 	private MentoringStatus status = MentoringStatus.INACTIVE;
+
 	private Format format = Format.SINGLE;
+
 	private MentoringType mentoringType = MentoringType.ONE_ON_ONE;
+
 	private int sessionCount = 1;
+
 	private int maxParticipants = 1;
+
 	private LocalDate endDate;
+
 	private boolean excludeHolidays;
+
 	@Column(nullable = false)
 	private int price;
 
@@ -128,6 +147,14 @@ public class Mentoring extends BaseAudit {
 				.isAfter(SessionPolicy.BUSINESS_END)) {
 			throw MentoringPolicyViolationException.sessionOutsideBusinessHours();
 		}
+	}
+
+	public List<RepeatPattern> getRepeatPatterns() {
+		return Collections.unmodifiableList(repeatPatterns);
+	}
+
+	public List<MentoringSession> getSessions() {
+		return Collections.unmodifiableList(sessions);
 	}
 
 	public void activate() {

--- a/src/main/java/com/goggles/mentoring_service/domain/mentoring/Mentoring.java
+++ b/src/main/java/com/goggles/mentoring_service/domain/mentoring/Mentoring.java
@@ -78,7 +78,7 @@ public class Mentoring extends BaseAudit {
 	private Mentoring(Mentor mentor, Category mentoringCategory, String title,
 			String subtitle, String description, MentoringDuration duration, MentoringStatus status,
 			MentoringType mentoringType, BookingType bookingType, int sessionCount,
-			int maxParticipants, boolean excludeHolidays, int price) {
+			int maxParticipants, boolean excludeHolidays, int price, LocalDate endDate) {
 		validateTypeConstraints(mentoringType, bookingType, sessionCount, maxParticipants);
 		if (price < 0) {
 			throw MentoringPolicyViolationException.invalidPrice();
@@ -97,6 +97,7 @@ public class Mentoring extends BaseAudit {
 		this.maxParticipants = maxParticipants;
 		this.excludeHolidays = excludeHolidays;
 		this.price = price;
+		this.endDate = endDate;
 	}
 
 	private static void validateTypeConstraints(MentoringType mentoringType,
@@ -119,13 +120,13 @@ public class Mentoring extends BaseAudit {
 			String title, String subtitle, String description,
 			MentoringDuration duration, MentoringStatus status,
 			MentoringType mentoringType, BookingType bookingType,
-			int sessionCount, int maxParticipants, boolean excludeHolidays, int price) {
+			int sessionCount, int maxParticipants, boolean excludeHolidays, int price, LocalDate endDate) {
 		Mentor mentor = Mentor.builder()
 				.id(mentorId).name(mentorName).field(mentorField).email(mentorEmail).userType(mentorType)
 				.build();
 		Category category = Category.of(categoryId, categoryName, categoryCode);
 		return new Mentoring(mentor, category, title, subtitle, description, duration,
-				status, mentoringType, bookingType, sessionCount, maxParticipants, excludeHolidays, price);
+				status, mentoringType, bookingType, sessionCount, maxParticipants, excludeHolidays, price, endDate);
 	}
 
 	public void activate() {

--- a/src/main/java/com/goggles/mentoring_service/domain/mentoring/Mentoring.java
+++ b/src/main/java/com/goggles/mentoring_service/domain/mentoring/Mentoring.java
@@ -13,6 +13,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.SQLRestriction;
 
+import java.time.Duration;
 import java.time.LocalDate;
 import java.time.LocalTime;
 import java.util.ArrayList;
@@ -49,7 +50,7 @@ public class Mentoring extends BaseAudit {
 
 	private MentoringStatus status = MentoringStatus.INACTIVE;
 
-	private BookingType bookingType = BookingType.ONE_TIME;
+	private Format format = Format.SINGLE;
 
 	private MentoringType mentoringType = MentoringType.ONE_ON_ONE;
 
@@ -77,9 +78,10 @@ public class Mentoring extends BaseAudit {
 
 	private Mentoring(Mentor mentor, Category mentoringCategory, String title,
 			String subtitle, String description, MentoringDuration duration, MentoringStatus status,
-			MentoringType mentoringType, BookingType bookingType, int sessionCount,
-			int maxParticipants, boolean excludeHolidays, int price, LocalDate endDate) {
-		validateTypeConstraints(mentoringType, bookingType, sessionCount, maxParticipants);
+			MentoringType mentoringType, Format format, int sessionCount,
+			int maxParticipants, boolean excludeHolidays, int price, LocalDate endDate,
+			List<RepeatPattern> repeatPatterns, List<MentoringSession> mentoringSessions) {
+		validateTypeConstraints(mentoringType, format, sessionCount, maxParticipants);
 		if (price < 0) {
 			throw MentoringPolicyViolationException.invalidPrice();
 		}
@@ -91,24 +93,26 @@ public class Mentoring extends BaseAudit {
 		this.description = description;
 		this.duration = duration;
 		this.status = status;
-		this.bookingType = bookingType;
+		this.format = format;
 		this.mentoringType = mentoringType;
 		this.sessionCount = sessionCount;
 		this.maxParticipants = maxParticipants;
 		this.excludeHolidays = excludeHolidays;
 		this.price = price;
 		this.endDate = endDate;
+		this.repeatPatterns.addAll(repeatPatterns);
+		this.sessions.addAll(mentoringSessions);
 	}
 
 	private static void validateTypeConstraints(MentoringType mentoringType,
-			BookingType bookingType, int sessionCount, int maxParticipants) {
+			Format format, int sessionCount, int maxParticipants) {
 		if (mentoringType == MentoringType.GROUP && maxParticipants <= 1) {
 			throw MentoringPolicyViolationException.groupMentoringMinParticipants();
 		}
 		if (mentoringType == MentoringType.ONE_ON_ONE && maxParticipants != 1) {
 			throw MentoringPolicyViolationException.oneOnOneMaxParticipants();
 		}
-		if (bookingType == BookingType.SELF_SELECT && sessionCount <= 1) {
+		if (format == Format.MULTI && sessionCount <= 1) {
 			throw MentoringPolicyViolationException.selfSelectMinSessions();
 		}
 	}
@@ -119,18 +123,21 @@ public class Mentoring extends BaseAudit {
 			UUID categoryId, String categoryName, String categoryCode,
 			String title, String subtitle, String description,
 			MentoringDuration duration, MentoringStatus status,
-			MentoringType mentoringType, BookingType bookingType,
-			int sessionCount, int maxParticipants, boolean excludeHolidays, int price, LocalDate endDate) {
+			MentoringType mentoringType, Format format,
+			int sessionCount, int maxParticipants, boolean excludeHolidays, int price, LocalDate endDate,
+			List<RepeatPattern> repeatPatterns,
+			List<MentoringSession> sessions) {
 		Mentor mentor = Mentor.builder()
 				.id(mentorId).name(mentorName).field(mentorField).email(mentorEmail).userType(mentorType)
 				.build();
 		Category category = Category.of(categoryId, categoryName, categoryCode);
 		return new Mentoring(mentor, category, title, subtitle, description, duration,
-				status, mentoringType, bookingType, sessionCount, maxParticipants, excludeHolidays, price, endDate);
+				status, mentoringType, format, sessionCount, maxParticipants, excludeHolidays,
+				price, endDate, repeatPatterns, sessions);
 	}
 
 	public void activate() {
-		if (bookingType == BookingType.AUTO_REPEAT && repeatPatterns.isEmpty()) {
+		if (format == Format.MULTI && repeatPatterns.isEmpty()) {
 			throw new RepeatPatternRequiredException();
 		}
 		this.status = MentoringStatus.ACTIVE;
@@ -149,8 +156,53 @@ public class Mentoring extends BaseAudit {
 		this.repeatPatterns.addAll(newPatterns);
 	}
 
-	public void addSessions(List<MentoringSession> sessions) {
-		this.sessions.addAll(sessions);
+	public void addSessions(List<MentoringSession> newSessions) {
+		newSessions.forEach(this::validateSession);
+		this.sessions.addAll(newSessions);
+	}
+
+	private void validateSession(MentoringSession session) {
+		validateSessionWithinWorkingHours(session);
+		validateSessionDuration(session);
+		validateSessionBeforeEndDate(session);
+	}
+
+	private void validateSessionBeforeEndDate(MentoringSession session) {
+		if (this.endDate != null && session.getSessionDate().isAfter(this.endDate)) {
+			throw MentoringPolicyViolationException.sessionBeyondEndDate();
+		}
+	}
+
+	private void validateSessionDuration(MentoringSession session) {
+		long minutes = Duration.between(session.getSessionStartTime(), session.getSessionEndTime()).toMinutes();
+		if (minutes != this.duration.getMinutes()) {
+			throw MentoringPolicyViolationException.sessionDurationMismatch();
+		}
+	}
+
+	private static void validateSessionWithinWorkingHours(MentoringSession session) {
+		if (session.getSessionStartTime().isBefore(SessionPolicy.BUSINESS_START)
+				|| session.getSessionEndTime().isAfter(SessionPolicy.BUSINESS_END)) {
+			throw MentoringPolicyViolationException.sessionOutsideBusinessHours();
+		}
+	}
+
+	public List<MentoringSession> generateSessions(LocalDate from, LocalDate to, HolidayProvider holidayProvider) {
+		if (format != Format.MULTI) {
+			throw MentoringPolicyViolationException.generateSessionsOnlyForAutoRepeat();
+		}
+		LocalDate effectiveTo = (endDate != null && endDate.isBefore(to)) ? endDate : to;
+		List<MentoringSession> generated = new ArrayList<>();
+
+		for (LocalDate date = from; !date.isAfter(effectiveTo); date = date.plusDays(1)) {
+			if (excludeHolidays && holidayProvider.isHoliday(date)) continue;
+			final LocalDate current = date;
+			repeatPatterns.stream()
+					.filter(p -> p.getDayOfWeek() == current.getDayOfWeek())
+					.map(p -> MentoringSession.of(current, p.getStartTime(), p.getEndTime()))
+					.forEach(generated::add);
+		}
+		return generated;
 	}
 
 	public void updateSessions(List<MentoringSession> newSessions, LocalDate now) {
@@ -181,8 +233,8 @@ public class Mentoring extends BaseAudit {
 
 	private MentoringSession findSession(LocalDate date, LocalTime startTime) {
 		return this.sessions.stream()
-				.filter(s -> s.getSessionDate()
-						.equals(date) && s.getSessionStartTime()
+				.filter(session -> session.getSessionDate()
+						.equals(date) && session.getSessionStartTime()
 						.equals(startTime))
 				.findFirst()
 				.orElseThrow(() -> new SessionNotFoundException(date, startTime));

--- a/src/main/java/com/goggles/mentoring_service/domain/mentoring/Mentoring.java
+++ b/src/main/java/com/goggles/mentoring_service/domain/mentoring/Mentoring.java
@@ -29,57 +29,41 @@ import java.util.UUID;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Mentoring extends BaseAudit {
 
-	@EmbeddedId
-	private MentoringId mentoringId;
-
-	@Embedded
-	private Mentor mentor;
-
-	@Embedded
-	private Category mentoringCategory;
-
-	@Column(length = 100, nullable = false)
-	private String title;
-
-	private String subtitle;
-
-	@Column(columnDefinition = "TEXT")
-	private String description;
-
-	private MentoringDuration duration;
-
-	private MentoringStatus status = MentoringStatus.INACTIVE;
-
-	private Format format = Format.SINGLE;
-
-	private MentoringType mentoringType = MentoringType.ONE_ON_ONE;
-
-	private int sessionCount = 1;
-
-	private int maxParticipants = 1;
-
-	private LocalDate endDate;
-
-	private boolean excludeHolidays;
-
-	@Column(nullable = false)
-	private int price;
-
 	@ElementCollection(fetch = FetchType.LAZY)
 	@CollectionTable(name = "P_REPEAT_PATTERN", joinColumns = @JoinColumn(name = "mentoring_id"))
 	@OrderColumn(name = "pattern_order")
 	private final List<RepeatPattern> repeatPatterns = new ArrayList<>();
-
 	@ElementCollection(fetch = FetchType.LAZY)
 	@CollectionTable(name = "P_MENTORING_SESSION", joinColumns = @JoinColumn(name = "mentoring_id"))
 	@OrderColumn(name = "session_order")
 	private final List<MentoringSession> sessions = new ArrayList<>();
+	@EmbeddedId
+	private MentoringId mentoringId;
+	@Embedded
+	private Mentor mentor;
+	@Embedded
+	private Category mentoringCategory;
+	@Column(length = 100, nullable = false)
+	private String title;
+	private String subtitle;
+	@Column(columnDefinition = "TEXT")
+	private String description;
+	private MentoringDuration duration;
+	private MentoringStatus status = MentoringStatus.INACTIVE;
+	private Format format = Format.SINGLE;
+	private MentoringType mentoringType = MentoringType.ONE_ON_ONE;
+	private int sessionCount = 1;
+	private int maxParticipants = 1;
+	private LocalDate endDate;
+	private boolean excludeHolidays;
+	@Column(nullable = false)
+	private int price;
 
 
-	private Mentoring(Mentor mentor, Category mentoringCategory, String title,
-			String subtitle, String description, MentoringDuration duration, MentoringStatus status,
-			MentoringType mentoringType, Format format, int sessionCount,
-			int maxParticipants, boolean excludeHolidays, int price, LocalDate endDate,
+	private Mentoring(Mentor mentor, Category mentoringCategory, String title, String subtitle,
+			String description, MentoringDuration duration, MentoringStatus status,
+			MentoringType mentoringType, Format format, int sessionCount, int maxParticipants,
+			boolean excludeHolidays, int price, LocalDate endDate,
 			List<RepeatPattern> repeatPatterns, List<MentoringSession> mentoringSessions) {
 		validateTypeConstraints(mentoringType, format, sessionCount, maxParticipants);
 		if (price < 0) {
@@ -104,8 +88,8 @@ public class Mentoring extends BaseAudit {
 		this.sessions.addAll(mentoringSessions);
 	}
 
-	private static void validateTypeConstraints(MentoringType mentoringType,
-			Format format, int sessionCount, int maxParticipants) {
+	private static void validateTypeConstraints(MentoringType mentoringType, Format format,
+			int sessionCount, int maxParticipants) {
 		if (mentoringType == MentoringType.GROUP && maxParticipants <= 1) {
 			throw MentoringPolicyViolationException.groupMentoringMinParticipants();
 		}
@@ -118,22 +102,32 @@ public class Mentoring extends BaseAudit {
 	}
 
 	@Builder
-	public static Mentoring create(
-			UUID mentorId, String mentorName, String mentorField, String mentorEmail, UserType mentorType,
-			UUID categoryId, String categoryName, String categoryCode,
-			String title, String subtitle, String description,
-			MentoringDuration duration, MentoringStatus status,
-			MentoringType mentoringType, Format format,
-			int sessionCount, int maxParticipants, boolean excludeHolidays, int price, LocalDate endDate,
-			List<RepeatPattern> repeatPatterns,
+	public static Mentoring create(UUID mentorId, String mentorName, String mentorField,
+			String mentorEmail, UserType mentorType, UUID categoryId, String categoryName,
+			String categoryCode, String title, String subtitle, String description,
+			MentoringDuration duration, MentoringStatus status, MentoringType mentoringType,
+			Format format, int sessionCount, int maxParticipants, boolean excludeHolidays,
+			int price, LocalDate endDate, List<RepeatPattern> repeatPatterns,
 			List<MentoringSession> sessions) {
 		Mentor mentor = Mentor.builder()
-				.id(mentorId).name(mentorName).field(mentorField).email(mentorEmail).userType(mentorType)
+				.id(mentorId)
+				.name(mentorName)
+				.field(mentorField)
+				.email(mentorEmail)
+				.userType(mentorType)
 				.build();
 		Category category = Category.of(categoryId, categoryName, categoryCode);
-		return new Mentoring(mentor, category, title, subtitle, description, duration,
-				status, mentoringType, format, sessionCount, maxParticipants, excludeHolidays,
-				price, endDate, repeatPatterns, sessions);
+		return new Mentoring(mentor, category, title, subtitle, description, duration, status,
+				mentoringType, format, sessionCount, maxParticipants, excludeHolidays, price,
+				endDate, repeatPatterns, sessions);
+	}
+
+	private static void validateSessionWithinWorkingHours(MentoringSession session) {
+		if (session.getSessionStartTime()
+				.isBefore(SessionPolicy.BUSINESS_START) || session.getSessionEndTime()
+				.isAfter(SessionPolicy.BUSINESS_END)) {
+			throw MentoringPolicyViolationException.sessionOutsideBusinessHours();
+		}
 	}
 
 	public void activate() {
@@ -168,26 +162,22 @@ public class Mentoring extends BaseAudit {
 	}
 
 	private void validateSessionBeforeEndDate(MentoringSession session) {
-		if (this.endDate != null && session.getSessionDate().isAfter(this.endDate)) {
+		if (this.endDate != null && session.getSessionDate()
+				.isAfter(this.endDate)) {
 			throw MentoringPolicyViolationException.sessionBeyondEndDate();
 		}
 	}
 
 	private void validateSessionDuration(MentoringSession session) {
-		long minutes = Duration.between(session.getSessionStartTime(), session.getSessionEndTime()).toMinutes();
+		long minutes = Duration.between(session.getSessionStartTime(), session.getSessionEndTime())
+				.toMinutes();
 		if (minutes != this.duration.getMinutes()) {
 			throw MentoringPolicyViolationException.sessionDurationMismatch();
 		}
 	}
 
-	private static void validateSessionWithinWorkingHours(MentoringSession session) {
-		if (session.getSessionStartTime().isBefore(SessionPolicy.BUSINESS_START)
-				|| session.getSessionEndTime().isAfter(SessionPolicy.BUSINESS_END)) {
-			throw MentoringPolicyViolationException.sessionOutsideBusinessHours();
-		}
-	}
-
-	public List<MentoringSession> generateSessions(LocalDate from, LocalDate to, HolidayProvider holidayProvider) {
+	public List<MentoringSession> generateSessions(LocalDate from, LocalDate to,
+			HolidayProvider holidayProvider) {
 		if (format != Format.MULTI) {
 			throw MentoringPolicyViolationException.generateSessionsOnlyForAutoRepeat();
 		}

--- a/src/main/java/com/goggles/mentoring_service/domain/mentoring/MentoringDuration.java
+++ b/src/main/java/com/goggles/mentoring_service/domain/mentoring/MentoringDuration.java
@@ -3,11 +3,7 @@ package com.goggles.mentoring_service.domain.mentoring;
 import lombok.Getter;
 
 public enum MentoringDuration {
-	MINUTES_30(30),
-	MINUTES_60(60),
-	MINUTES_90(90),
-	MINUTES_120(120),
-	MINUTES_150(150),
+	MINUTES_30(30), MINUTES_60(60), MINUTES_90(90), MINUTES_120(120), MINUTES_150(150),
 	MINUTES_180(180);
 
 	@Getter

--- a/src/main/java/com/goggles/mentoring_service/domain/mentoring/MentoringId.java
+++ b/src/main/java/com/goggles/mentoring_service/domain/mentoring/MentoringId.java
@@ -9,16 +9,14 @@ import java.io.Serializable;
 import java.util.UUID;
 
 @Embeddable
-public record MentoringId (@JdbcTypeCode(SqlTypes.UUID)
-						   @Column(length=36, name="mentoring_id")
-	UUID mentoringId
-) implements Serializable {
+public record MentoringId(
+		@JdbcTypeCode(SqlTypes.UUID) @Column(length = 36, name = "mentoring_id") UUID mentoringId) implements Serializable {
 
-	public static MentoringId of(){
+	public static MentoringId of() {
 		return new MentoringId(UUID.randomUUID());
 	}
 
-	public static MentoringId of(String mentoringIdString){
+	public static MentoringId of(String mentoringIdString) {
 		return new MentoringId(UUID.fromString(mentoringIdString));
 	}
 }

--- a/src/main/java/com/goggles/mentoring_service/domain/mentoring/MentoringSession.java
+++ b/src/main/java/com/goggles/mentoring_service/domain/mentoring/MentoringSession.java
@@ -20,7 +20,7 @@ public class MentoringSession {
 	private LocalTime sessionEndTime;
 	private SessionStatus status = SessionStatus.AVAILABLE;
 
-	public static MentoringSession of(LocalDate date, LocalTime startTime, LocalTime endTime) {
+	static MentoringSession of(LocalDate date, LocalTime startTime, LocalTime endTime) {
 		if (startTime.isAfter(endTime) || startTime.equals(endTime)) {
 			throw InvalidTimeRangeException.forSession();
 		}

--- a/src/main/java/com/goggles/mentoring_service/domain/mentoring/MentoringSession.java
+++ b/src/main/java/com/goggles/mentoring_service/domain/mentoring/MentoringSession.java
@@ -20,36 +20,36 @@ public class MentoringSession {
 	private LocalTime sessionEndTime;
 	private SessionStatus status = SessionStatus.AVAILABLE;
 
-	 static MentoringSession of(LocalDate date, LocalTime startTime, LocalTime endTime) {
-		MentoringSession session = new MentoringSession();
-		session.sessionDate = date;
-		if(startTime.isAfter(endTime) || startTime.equals(endTime)) {
+	public static MentoringSession of(LocalDate date, LocalTime startTime, LocalTime endTime) {
+		if (startTime.isAfter(endTime) || startTime.equals(endTime)) {
 			throw InvalidTimeRangeException.forSession();
 		}
+		MentoringSession session = new MentoringSession();
+		session.sessionDate = date;
 		session.sessionStartTime = startTime;
 		session.sessionEndTime = endTime;
 		return session;
 	}
 
-	 void deactivate() {
+	void deactivate() {
 		if (this.status == SessionStatus.BOOKED) {
 			throw new BookedSessionStatusCannotBeChangedException();
 		}
 		this.status = SessionStatus.NOT_AVAILABLE;
 	}
 
-	 void activate() {
+	void activate() {
 		if (this.status == SessionStatus.BOOKED) {
 			throw new BookedSessionStatusCannotBeChangedException();
 		}
 		this.status = SessionStatus.AVAILABLE;
 	}
 
-	 boolean isBooked() {
+	boolean isBooked() {
 		return this.status == SessionStatus.BOOKED;
 	}
 
-	 void book() {
+	void book() {
 		if (this.status != SessionStatus.AVAILABLE) {
 			throw new SessionNotAvailableException();
 		}

--- a/src/main/java/com/goggles/mentoring_service/domain/mentoring/MentoringStatus.java
+++ b/src/main/java/com/goggles/mentoring_service/domain/mentoring/MentoringStatus.java
@@ -1,6 +1,5 @@
 package com.goggles.mentoring_service.domain.mentoring;
 
 public enum MentoringStatus {
-	ACTIVE,
-	INACTIVE
+	ACTIVE, INACTIVE
 }

--- a/src/main/java/com/goggles/mentoring_service/domain/mentoring/MentoringType.java
+++ b/src/main/java/com/goggles/mentoring_service/domain/mentoring/MentoringType.java
@@ -1,6 +1,5 @@
 package com.goggles.mentoring_service.domain.mentoring;
 
 public enum MentoringType {
-	ONE_ON_ONE,
-	GROUP
+	ONE_ON_ONE, GROUP
 }

--- a/src/main/java/com/goggles/mentoring_service/domain/mentoring/RepeatPattern.java
+++ b/src/main/java/com/goggles/mentoring_service/domain/mentoring/RepeatPattern.java
@@ -19,13 +19,12 @@ public class RepeatPattern {
 	private LocalTime startTime;
 	private LocalTime endTime;
 
-
 	public static RepeatPattern of(DayOfWeek dayOfWeek, LocalTime startTime, LocalTime endTime) {
-		RepeatPattern pattern = new RepeatPattern();
-		pattern.dayOfWeek = dayOfWeek;
 		if (startTime.isAfter(endTime) || startTime.equals(endTime)) {
 			throw InvalidTimeRangeException.forRepeatPattern();
 		}
+		RepeatPattern pattern = new RepeatPattern();
+		pattern.dayOfWeek = dayOfWeek;
 		pattern.startTime = startTime;
 		pattern.endTime = endTime;
 		return pattern;

--- a/src/main/java/com/goggles/mentoring_service/domain/mentoring/SessionPolicy.java
+++ b/src/main/java/com/goggles/mentoring_service/domain/mentoring/SessionPolicy.java
@@ -4,8 +4,8 @@ import java.time.LocalTime;
 
 public final class SessionPolicy {
 
-    public static final LocalTime BUSINESS_START = LocalTime.of(6, 0);
-    public static final LocalTime BUSINESS_END = LocalTime.of(22, 0);
+	public static final LocalTime BUSINESS_START = LocalTime.of(6, 0);
+	public static final LocalTime BUSINESS_END = LocalTime.of(22, 0);
 
-    private SessionPolicy() {}
+	private SessionPolicy() {}
 }

--- a/src/main/java/com/goggles/mentoring_service/domain/mentoring/SessionPolicy.java
+++ b/src/main/java/com/goggles/mentoring_service/domain/mentoring/SessionPolicy.java
@@ -1,0 +1,11 @@
+package com.goggles.mentoring_service.domain.mentoring;
+
+import java.time.LocalTime;
+
+public final class SessionPolicy {
+
+    public static final LocalTime BUSINESS_START = LocalTime.of(6, 0);
+    public static final LocalTime BUSINESS_END = LocalTime.of(22, 0);
+
+    private SessionPolicy() {}
+}

--- a/src/main/java/com/goggles/mentoring_service/domain/mentoring/SessionStatus.java
+++ b/src/main/java/com/goggles/mentoring_service/domain/mentoring/SessionStatus.java
@@ -1,7 +1,5 @@
 package com.goggles.mentoring_service.domain.mentoring;
 
 public enum SessionStatus {
-	AVAILABLE,
-	BOOKED,
-	NOT_AVAILABLE
+	AVAILABLE, BOOKED, NOT_AVAILABLE
 }

--- a/src/main/java/com/goggles/mentoring_service/domain/mentoring/exception/MentoringPolicyViolationException.java
+++ b/src/main/java/com/goggles/mentoring_service/domain/mentoring/exception/MentoringPolicyViolationException.java
@@ -23,4 +23,20 @@ public class MentoringPolicyViolationException extends MentoringValidationExcept
 	public static MentoringPolicyViolationException selfSelectMinSessions() {
 		return new MentoringPolicyViolationException("자유 선택 예약은 세션 수가 2회 이상이어야 합니다.");
 	}
+
+	public static MentoringPolicyViolationException sessionOutsideBusinessHours() {
+		return new MentoringPolicyViolationException("세션은 오전 6시부터 오후 10시 사이에만 등록할 수 있습니다.");
+	}
+
+	public static MentoringPolicyViolationException sessionDurationMismatch() {
+		return new MentoringPolicyViolationException("세션 시간이 멘토링 소요 시간과 일치하지 않습니다.");
+	}
+
+	public static MentoringPolicyViolationException sessionBeyondEndDate() {
+		return new MentoringPolicyViolationException("세션 날짜가 멘토링 종료일을 초과할 수 없습니다.");
+	}
+
+	public static MentoringPolicyViolationException generateSessionsOnlyForAutoRepeat() {
+		return new MentoringPolicyViolationException("세션 자동 생성은 MULTI 포맷 멘토링만 가능합니다.");
+	}
 }

--- a/src/main/java/com/goggles/mentoring_service/infrastructure/HolidayProviderImpl.java
+++ b/src/main/java/com/goggles/mentoring_service/infrastructure/HolidayProviderImpl.java
@@ -10,20 +10,19 @@ import java.util.Set;
 @Component
 public class HolidayProviderImpl implements HolidayProvider {
 
-    // 양력 고정 공휴일 (음력 기반 공휴일은 추후 외부 API 연동 시 추가)
-    private static final Set<MonthDay> FIXED_HOLIDAYS = Set.of(
-            MonthDay.of(1, 1),   // 새해
-            MonthDay.of(3, 1),   // 삼일절
-            MonthDay.of(5, 5),   // 어린이날
-            MonthDay.of(6, 6),   // 현충일
-            MonthDay.of(8, 15),  // 광복절
-            MonthDay.of(10, 3),  // 개천절
-            MonthDay.of(10, 9),  // 한글날
-            MonthDay.of(12, 25)  // 크리스마스
-    );
+	// 양력 고정 공휴일 (음력 기반 공휴일은 추후 외부 API 연동 시 추가)
+	private static final Set<MonthDay> FIXED_HOLIDAYS = Set.of(MonthDay.of(1, 1),   // 새해
+			MonthDay.of(3, 1),   // 삼일절
+			MonthDay.of(5, 5),   // 어린이날
+			MonthDay.of(6, 6),   // 현충일
+			MonthDay.of(8, 15),  // 광복절
+			MonthDay.of(10, 3),  // 개천절
+			MonthDay.of(10, 9),  // 한글날
+			MonthDay.of(12, 25)  // 크리스마스
+	);
 
-    @Override
-    public boolean isHoliday(LocalDate date) {
-        return FIXED_HOLIDAYS.contains(MonthDay.from(date));
-    }
+	@Override
+	public boolean isHoliday(LocalDate date) {
+		return FIXED_HOLIDAYS.contains(MonthDay.from(date));
+	}
 }

--- a/src/main/java/com/goggles/mentoring_service/infrastructure/HolidayProviderImpl.java
+++ b/src/main/java/com/goggles/mentoring_service/infrastructure/HolidayProviderImpl.java
@@ -1,0 +1,29 @@
+package com.goggles.mentoring_service.infrastructure;
+
+import com.goggles.mentoring_service.domain.mentoring.HolidayProvider;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDate;
+import java.time.MonthDay;
+import java.util.Set;
+
+@Component
+public class HolidayProviderImpl implements HolidayProvider {
+
+    // 양력 고정 공휴일 (음력 기반 공휴일은 추후 외부 API 연동 시 추가)
+    private static final Set<MonthDay> FIXED_HOLIDAYS = Set.of(
+            MonthDay.of(1, 1),   // 새해
+            MonthDay.of(3, 1),   // 삼일절
+            MonthDay.of(5, 5),   // 어린이날
+            MonthDay.of(6, 6),   // 현충일
+            MonthDay.of(8, 15),  // 광복절
+            MonthDay.of(10, 3),  // 개천절
+            MonthDay.of(10, 9),  // 한글날
+            MonthDay.of(12, 25)  // 크리스마스
+    );
+
+    @Override
+    public boolean isHoliday(LocalDate date) {
+        return FIXED_HOLIDAYS.contains(MonthDay.from(date));
+    }
+}

--- a/src/main/java/com/goggles/mentoring_service/infrastructure/config/WebMvcConfig.java
+++ b/src/main/java/com/goggles/mentoring_service/infrastructure/config/WebMvcConfig.java
@@ -1,0 +1,21 @@
+package com.goggles.mentoring_service.infrastructure.config;
+
+import com.goggles.mentoring_service.presentation.support.UserContextArgumentResolver;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+import java.util.List;
+
+@Configuration
+@RequiredArgsConstructor
+public class WebMvcConfig implements WebMvcConfigurer {
+
+	private final UserContextArgumentResolver userContextArgumentResolver;
+
+	@Override
+	public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
+		resolvers.add(userContextArgumentResolver);
+	}
+}

--- a/src/main/java/com/goggles/mentoring_service/infrastructure/persistence/MentoringCategoryRepositoryImpl.java
+++ b/src/main/java/com/goggles/mentoring_service/infrastructure/persistence/MentoringCategoryRepositoryImpl.java
@@ -1,0 +1,29 @@
+package com.goggles.mentoring_service.infrastructure.persistence;
+
+import com.goggles.mentoring_service.domain.category.MentoringCategory;
+import com.goggles.mentoring_service.domain.category.MentoringCategoryId;
+import com.goggles.mentoring_service.domain.category.repository.MentoringCategoryRepository;
+import com.goggles.mentoring_service.infrastructure.persistence.jpa.MentoringCategoryJpaRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+@RequiredArgsConstructor
+public class MentoringCategoryRepositoryImpl implements MentoringCategoryRepository {
+
+	private final MentoringCategoryJpaRepository jpaRepository;
+
+	@Override
+	public MentoringCategory save(MentoringCategory category) {
+		return jpaRepository.save(category);
+	}
+
+	@Override
+	public Optional<MentoringCategory> findById(MentoringCategoryId id) {
+		return jpaRepository.findById(id);
+	}
+
+}

--- a/src/main/java/com/goggles/mentoring_service/infrastructure/persistence/MentoringCategoryRepositoryImpl.java
+++ b/src/main/java/com/goggles/mentoring_service/infrastructure/persistence/MentoringCategoryRepositoryImpl.java
@@ -22,8 +22,17 @@ public class MentoringCategoryRepositoryImpl implements MentoringCategoryReposit
 	}
 
 	@Override
+	public void saveAll(List<MentoringCategory> categories) {
+		jpaRepository.saveAll(categories);
+	}
+
+	@Override
 	public Optional<MentoringCategory> findById(MentoringCategoryId id) {
 		return jpaRepository.findById(id);
 	}
 
+	@Override
+	public List<MentoringCategory> findByActiveIsTrue() {
+		return jpaRepository.findByActiveIsTrue();
+	}
 }

--- a/src/main/java/com/goggles/mentoring_service/infrastructure/persistence/MentoringRepositoryImpl.java
+++ b/src/main/java/com/goggles/mentoring_service/infrastructure/persistence/MentoringRepositoryImpl.java
@@ -1,0 +1,27 @@
+package com.goggles.mentoring_service.infrastructure.persistence;
+
+import com.goggles.mentoring_service.domain.mentoring.Mentoring;
+import com.goggles.mentoring_service.domain.mentoring.MentoringId;
+import com.goggles.mentoring_service.domain.mentoring.repository.MentoringRepository;
+import com.goggles.mentoring_service.infrastructure.persistence.jpa.MentoringJpaRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+@RequiredArgsConstructor
+public class MentoringRepositoryImpl implements MentoringRepository {
+
+	private final MentoringJpaRepository jpaRepository;
+
+	@Override
+	public void save(Mentoring mentoring) {
+		jpaRepository.save(mentoring);
+	}
+
+	@Override
+	public Optional<Mentoring> findById(MentoringId id) {
+		return jpaRepository.findById(id);
+	}
+}

--- a/src/main/java/com/goggles/mentoring_service/infrastructure/persistence/jpa/MentoringCategoryJpaRepository.java
+++ b/src/main/java/com/goggles/mentoring_service/infrastructure/persistence/jpa/MentoringCategoryJpaRepository.java
@@ -1,0 +1,10 @@
+package com.goggles.mentoring_service.infrastructure.persistence.jpa;
+
+import com.goggles.mentoring_service.domain.category.MentoringCategory;
+import com.goggles.mentoring_service.domain.category.MentoringCategoryId;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface MentoringCategoryJpaRepository extends JpaRepository<MentoringCategory, MentoringCategoryId> {
+}

--- a/src/main/java/com/goggles/mentoring_service/infrastructure/persistence/jpa/MentoringCategoryJpaRepository.java
+++ b/src/main/java/com/goggles/mentoring_service/infrastructure/persistence/jpa/MentoringCategoryJpaRepository.java
@@ -7,4 +7,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import java.util.List;
 
 public interface MentoringCategoryJpaRepository extends JpaRepository<MentoringCategory, MentoringCategoryId> {
+	List<MentoringCategory> findByActiveIsTrue();
 }

--- a/src/main/java/com/goggles/mentoring_service/infrastructure/persistence/jpa/MentoringJpaRepository.java
+++ b/src/main/java/com/goggles/mentoring_service/infrastructure/persistence/jpa/MentoringJpaRepository.java
@@ -4,5 +4,4 @@ import com.goggles.mentoring_service.domain.mentoring.Mentoring;
 import com.goggles.mentoring_service.domain.mentoring.MentoringId;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface MentoringJpaRepository extends JpaRepository<Mentoring, MentoringId> {
-}
+public interface MentoringJpaRepository extends JpaRepository<Mentoring, MentoringId> {}

--- a/src/main/java/com/goggles/mentoring_service/infrastructure/persistence/jpa/MentoringJpaRepository.java
+++ b/src/main/java/com/goggles/mentoring_service/infrastructure/persistence/jpa/MentoringJpaRepository.java
@@ -1,0 +1,8 @@
+package com.goggles.mentoring_service.infrastructure.persistence.jpa;
+
+import com.goggles.mentoring_service.domain.mentoring.Mentoring;
+import com.goggles.mentoring_service.domain.mentoring.MentoringId;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MentoringJpaRepository extends JpaRepository<Mentoring, MentoringId> {
+}

--- a/src/main/java/com/goggles/mentoring_service/presentation/MentoringController.java
+++ b/src/main/java/com/goggles/mentoring_service/presentation/MentoringController.java
@@ -1,0 +1,30 @@
+package com.goggles.mentoring_service.presentation;
+
+import com.goggles.mentoring_service.application.command.MentoringCommand;
+import com.goggles.mentoring_service.application.service.MentoringService;
+import com.goggles.mentoring_service.presentation.dto.MentoringRequest;
+import com.goggles.mentoring_service.presentation.dto.MentoringResponse;
+import com.goggles.mentoring_service.presentation.support.UserContext;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.UUID;
+
+@RestController
+@RequestMapping("/api/v1/mentorings")
+@RequiredArgsConstructor
+public class MentoringController {
+
+	private final MentoringService mentoringService;
+
+	@PostMapping
+	@ResponseStatus(HttpStatus.CREATED)
+	public MentoringResponse.Create createMentoring(UserContext userContext,
+			@Valid @RequestBody MentoringRequest.Create request) {
+		MentoringCommand.Create command = request.toCommand(userContext);
+		UUID mentoringId = mentoringService.createMentoring(command);
+		return new MentoringResponse.Create(mentoringId);
+	}
+}

--- a/src/main/java/com/goggles/mentoring_service/presentation/dto/MentoringRequest.java
+++ b/src/main/java/com/goggles/mentoring_service/presentation/dto/MentoringRequest.java
@@ -1,43 +1,50 @@
 package com.goggles.mentoring_service.presentation.dto;
 
 import com.goggles.mentoring_service.application.command.MentoringCommand;
-import com.goggles.mentoring_service.domain.mentoring.BookingType;
+import com.goggles.mentoring_service.application.command.SessionSlot;
+import com.goggles.mentoring_service.application.command.TimeSchedules;
+import com.goggles.mentoring_service.domain.mentoring.Format;
 import com.goggles.mentoring_service.domain.mentoring.MentoringDuration;
 import com.goggles.mentoring_service.domain.mentoring.MentoringType;
 import com.goggles.mentoring_service.presentation.support.UserContext;
-import jakarta.validation.constraints.Min;
-import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.NotNull;
-import jakarta.validation.constraints.Size;
+import jakarta.validation.constraints.*;
 
+import java.time.DayOfWeek;
 import java.time.LocalDate;
+import java.time.LocalTime;
+import java.util.List;
 import java.util.UUID;
 
 public class MentoringRequest {
 
-	public record Create(
-			@NotNull UUID categoryId,
-			@NotBlank @Size(max = 100) String title,
-			String subtitle,
-			String description,
-			@NotNull MentoringDuration duration,
-			@NotNull MentoringType mentoringType,
-			@NotNull BookingType bookingType,
-			@Min(1) int sessionCount,
-			@Min(1) int maxParticipants,
-			boolean excludeHolidays,
-			@Min(0) int price,
-			LocalDate endDate
-	) {
-
+	public record Create(@NotNull UUID categoryId, @NotBlank @Size(max = 100) String title,
+						 String subtitle, String description, @NotNull MentoringDuration duration,
+						 @NotNull MentoringType mentoringType, @NotNull Format format,
+						 @Min(1) int sessionCount, @Min(1) int maxParticipants,
+						 boolean excludeHolidays, @Min(0) int price, LocalDate endDate,
+						 @NotEmpty List<SessionDto> sessions,
+						 @NotEmpty List<RepeatPatternDto> repeatPatterns) {
 		public MentoringCommand.Create toCommand(UserContext userContext) {
-			return new MentoringCommand.Create(
-					userContext.userId(), userContext.userName(), userContext.userField(),
-					userContext.userEmail(), userContext.userType(),
-					categoryId(), title(), subtitle(), description(),
-					duration(), mentoringType(), bookingType(),
-					sessionCount(), maxParticipants(), excludeHolidays(), price(), endDate()
-			);
+			List<SessionSlot> sessionSlots = sessions().stream()
+					.map(session -> new SessionSlot(session.date(), session.startTime(),
+							session.endTime()))
+					.toList();
+
+			List<TimeSchedules> patterns = repeatPatterns().stream()
+					.map(pattern -> new TimeSchedules(pattern.dayOfWeek(), pattern.startTime(),
+							pattern.endTime()))
+					.toList();
+
+			return new MentoringCommand.Create(userContext.userId(), userContext.userName(),
+					userContext.userField(), userContext.userEmail(), userContext.userType(),
+					categoryId(), title(), subtitle(), description(), duration(), mentoringType(),
+					format(), sessionCount(), maxParticipants(), excludeHolidays(), price(),
+					endDate(), sessionSlots, patterns);
 		}
+
+		public record SessionDto(LocalDate date, LocalTime startTime, LocalTime endTime) {}
+
+		public record RepeatPatternDto(DayOfWeek dayOfWeek, LocalTime startTime,
+									   LocalTime endTime) {}
 	}
 }

--- a/src/main/java/com/goggles/mentoring_service/presentation/dto/MentoringRequest.java
+++ b/src/main/java/com/goggles/mentoring_service/presentation/dto/MentoringRequest.java
@@ -1,0 +1,43 @@
+package com.goggles.mentoring_service.presentation.dto;
+
+import com.goggles.mentoring_service.application.command.MentoringCommand;
+import com.goggles.mentoring_service.domain.mentoring.BookingType;
+import com.goggles.mentoring_service.domain.mentoring.MentoringDuration;
+import com.goggles.mentoring_service.domain.mentoring.MentoringType;
+import com.goggles.mentoring_service.presentation.support.UserContext;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+
+import java.time.LocalDate;
+import java.util.UUID;
+
+public class MentoringRequest {
+
+	public record Create(
+			@NotNull UUID categoryId,
+			@NotBlank @Size(max = 100) String title,
+			String subtitle,
+			String description,
+			@NotNull MentoringDuration duration,
+			@NotNull MentoringType mentoringType,
+			@NotNull BookingType bookingType,
+			@Min(1) int sessionCount,
+			@Min(1) int maxParticipants,
+			boolean excludeHolidays,
+			@Min(0) int price,
+			LocalDate endDate
+	) {
+
+		public MentoringCommand.Create toCommand(UserContext userContext) {
+			return new MentoringCommand.Create(
+					userContext.userId(), userContext.userName(), userContext.userField(),
+					userContext.userEmail(), userContext.userType(),
+					categoryId(), title(), subtitle(), description(),
+					duration(), mentoringType(), bookingType(),
+					sessionCount(), maxParticipants(), excludeHolidays(), price(), endDate()
+			);
+		}
+	}
+}

--- a/src/main/java/com/goggles/mentoring_service/presentation/dto/MentoringRequest.java
+++ b/src/main/java/com/goggles/mentoring_service/presentation/dto/MentoringRequest.java
@@ -22,8 +22,8 @@ public class MentoringRequest {
 						 @NotNull MentoringType mentoringType, @NotNull Format format,
 						 @Min(1) int sessionCount, @Min(1) int maxParticipants,
 						 boolean excludeHolidays, @Min(0) int price, LocalDate endDate,
-						 @NotEmpty List<SessionDto> sessions,
-						 @NotEmpty List<RepeatPatternDto> repeatPatterns) {
+						 @Valid @NotEmpty List<SessionDto> sessions,
+						 @Valid @NotEmpty List<RepeatPatternDto> repeatPatterns) {
 		public MentoringCommand.Create toCommand(UserContext userContext) {
 			List<SessionSlot> sessionSlots = sessions().stream()
 					.map(session -> new SessionSlot(session.date(), session.startTime(),
@@ -42,9 +42,10 @@ public class MentoringRequest {
 					endDate(), sessionSlots, patterns);
 		}
 
-		public record SessionDto(LocalDate date, LocalTime startTime, LocalTime endTime) {}
+		public record SessionDto(@NotNull LocalDate date, @NotNull LocalTime startTime,
+								 @NotNull LocalTime endTime) {}
 
-		public record RepeatPatternDto(DayOfWeek dayOfWeek, LocalTime startTime,
-									   LocalTime endTime) {}
+		public record RepeatPatternDto(@NotNull DayOfWeek dayOfWeek, @NotNull LocalTime startTime,
+									   @NotNull LocalTime endTime) {}
 	}
 }

--- a/src/main/java/com/goggles/mentoring_service/presentation/dto/MentoringResponse.java
+++ b/src/main/java/com/goggles/mentoring_service/presentation/dto/MentoringResponse.java
@@ -1,0 +1,8 @@
+package com.goggles.mentoring_service.presentation.dto;
+
+import java.util.UUID;
+
+public class MentoringResponse {
+
+	public record Create(UUID mentoringId) {}
+}

--- a/src/main/java/com/goggles/mentoring_service/presentation/support/UserContext.java
+++ b/src/main/java/com/goggles/mentoring_service/presentation/support/UserContext.java
@@ -4,11 +4,5 @@ import com.goggles.mentoring_service.domain.common.UserType;
 
 import java.util.UUID;
 
-public record UserContext(
-		UUID userId,
-		UserType userType,
-		String userName,
-		String userEmail,
-		String userField
-) {
-}
+public record UserContext(UUID userId, UserType userType, String userName, String userEmail,
+						  String userField) {}

--- a/src/main/java/com/goggles/mentoring_service/presentation/support/UserContext.java
+++ b/src/main/java/com/goggles/mentoring_service/presentation/support/UserContext.java
@@ -1,0 +1,14 @@
+package com.goggles.mentoring_service.presentation.support;
+
+import com.goggles.mentoring_service.domain.common.UserType;
+
+import java.util.UUID;
+
+public record UserContext(
+		UUID userId,
+		UserType userType,
+		String userName,
+		String userEmail,
+		String userField
+) {
+}

--- a/src/main/java/com/goggles/mentoring_service/presentation/support/UserContextArgumentResolver.java
+++ b/src/main/java/com/goggles/mentoring_service/presentation/support/UserContextArgumentResolver.java
@@ -1,13 +1,16 @@
 package com.goggles.mentoring_service.presentation.support;
 
+import com.goggles.common.exception.BadRequestException;
 import com.goggles.mentoring_service.domain.common.UserType;
 import jakarta.servlet.http.HttpServletRequest;
 import org.springframework.core.MethodParameter;
+import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Component;
 import org.springframework.web.bind.support.WebDataBinderFactory;
 import org.springframework.web.context.request.NativeWebRequest;
 import org.springframework.web.method.support.HandlerMethodArgumentResolver;
 import org.springframework.web.method.support.ModelAndViewContainer;
+import org.springframework.web.server.ResponseStatusException;
 
 import java.util.UUID;
 
@@ -25,9 +28,13 @@ public class UserContextArgumentResolver implements HandlerMethodArgumentResolve
 			ModelAndViewContainer mavContainer, NativeWebRequest webRequest,
 			WebDataBinderFactory binderFactory) {
 		HttpServletRequest request = webRequest.getNativeRequest(HttpServletRequest.class);
-		return new UserContext(UUID.fromString(request.getHeader("X-User-Id")),
-				UserType.valueOf(request.getHeader("X-User-Type")),
-				request.getHeader("X-User-Name"), request.getHeader("X-User-Email"),
-				request.getHeader("X-User-Field"));
+		try {
+			return new UserContext(UUID.fromString(request.getHeader("X-User-Id")),
+					UserType.valueOf(request.getHeader("X-User-Type")),
+					request.getHeader("X-User-Name"), request.getHeader("X-User-Email"),
+					request.getHeader("X-User-Field"));
+		} catch (IllegalArgumentException | NullPointerException e) {
+			throw new BadRequestException("Invalid user context in request headers",e.getMessage());
+		}
 	}
 }

--- a/src/main/java/com/goggles/mentoring_service/presentation/support/UserContextArgumentResolver.java
+++ b/src/main/java/com/goggles/mentoring_service/presentation/support/UserContextArgumentResolver.java
@@ -16,19 +16,18 @@ public class UserContextArgumentResolver implements HandlerMethodArgumentResolve
 
 	@Override
 	public boolean supportsParameter(MethodParameter parameter) {
-		return parameter.getParameterType().equals(UserContext.class);
+		return parameter.getParameterType()
+				.equals(UserContext.class);
 	}
 
 	@Override
-	public UserContext resolveArgument(MethodParameter parameter, ModelAndViewContainer mavContainer,
-			NativeWebRequest webRequest, WebDataBinderFactory binderFactory) {
+	public UserContext resolveArgument(MethodParameter parameter,
+			ModelAndViewContainer mavContainer, NativeWebRequest webRequest,
+			WebDataBinderFactory binderFactory) {
 		HttpServletRequest request = webRequest.getNativeRequest(HttpServletRequest.class);
-		return new UserContext(
-				UUID.fromString(request.getHeader("X-User-Id")),
+		return new UserContext(UUID.fromString(request.getHeader("X-User-Id")),
 				UserType.valueOf(request.getHeader("X-User-Type")),
-				request.getHeader("X-User-Name"),
-				request.getHeader("X-User-Email"),
-				request.getHeader("X-User-Field")
-		);
+				request.getHeader("X-User-Name"), request.getHeader("X-User-Email"),
+				request.getHeader("X-User-Field"));
 	}
 }

--- a/src/main/java/com/goggles/mentoring_service/presentation/support/UserContextArgumentResolver.java
+++ b/src/main/java/com/goggles/mentoring_service/presentation/support/UserContextArgumentResolver.java
@@ -1,0 +1,34 @@
+package com.goggles.mentoring_service.presentation.support;
+
+import com.goggles.mentoring_service.domain.common.UserType;
+import jakarta.servlet.http.HttpServletRequest;
+import org.springframework.core.MethodParameter;
+import org.springframework.stereotype.Component;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+
+import java.util.UUID;
+
+@Component
+public class UserContextArgumentResolver implements HandlerMethodArgumentResolver {
+
+	@Override
+	public boolean supportsParameter(MethodParameter parameter) {
+		return parameter.getParameterType().equals(UserContext.class);
+	}
+
+	@Override
+	public UserContext resolveArgument(MethodParameter parameter, ModelAndViewContainer mavContainer,
+			NativeWebRequest webRequest, WebDataBinderFactory binderFactory) {
+		HttpServletRequest request = webRequest.getNativeRequest(HttpServletRequest.class);
+		return new UserContext(
+				UUID.fromString(request.getHeader("X-User-Id")),
+				UserType.valueOf(request.getHeader("X-User-Type")),
+				request.getHeader("X-User-Name"),
+				request.getHeader("X-User-Email"),
+				request.getHeader("X-User-Field")
+		);
+	}
+}

--- a/src/test/java/com/goggles/mentoring_service/MentoringServerApplicationTests.java
+++ b/src/test/java/com/goggles/mentoring_service/MentoringServerApplicationTests.java
@@ -1,9 +1,13 @@
 package com.goggles.mentoring_service;
 
 import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
 
 @SpringBootTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.ANY)
+@ActiveProfiles("test")
 class MentoringServerApplicationTests {
 
 	@Test

--- a/src/test/java/com/goggles/mentoring_service/application/service/MentoringServiceIntegrationTest.java
+++ b/src/test/java/com/goggles/mentoring_service/application/service/MentoringServiceIntegrationTest.java
@@ -1,0 +1,98 @@
+package com.goggles.mentoring_service.application.service;
+
+import com.goggles.mentoring_service.application.command.MentoringCommand;
+import com.goggles.mentoring_service.config.TestAuditConfig;
+import com.goggles.mentoring_service.domain.category.MentoringCategory;
+import com.goggles.mentoring_service.domain.category.repository.MentoringCategoryRepository;
+import com.goggles.mentoring_service.domain.common.UserType;
+import com.goggles.mentoring_service.domain.mentoring.Format;
+import com.goggles.mentoring_service.domain.mentoring.Mentoring;
+import com.goggles.mentoring_service.domain.mentoring.MentoringId;
+import com.goggles.mentoring_service.domain.mentoring.MentoringStatus;
+import com.goggles.mentoring_service.domain.mentoring.MentoringType;
+import com.goggles.mentoring_service.domain.mentoring.repository.MentoringRepository;
+import jakarta.persistence.EntityManager;
+import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.DayOfWeek;
+import java.util.List;
+import java.util.UUID;
+
+import static com.goggles.mentoring_service.domain.mentoring.MentoringFixture.*;
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.ANY)
+@Import(TestAuditConfig.class)
+@ActiveProfiles("test")
+@Transactional
+class MentoringServiceIntegrationTest {
+
+    private static final Logger log = LoggerFactory.getLogger(MentoringServiceIntegrationTest.class);
+
+    @Autowired
+    private MentoringService mentoringService;
+
+    @Autowired
+    private MentoringRepository mentoringRepository;
+
+    @Autowired
+    private MentoringCategoryRepository categoryRepository;
+
+    @Autowired
+    private EntityManager em;
+
+    @Test
+    void createMentoring_persists_to_db() {
+        MentoringCategory category = MentoringCategory.create(
+                MENTOR_ID, UserType.MASTER, CATEGORY_NAME, CATEGORY_CODE);
+        categoryRepository.save(category);
+
+        MentoringCommand.Create command = new MentoringCommand.Create(
+                MENTOR_ID, MENTOR_NAME, MENTOR_FIELD, MENTOR_EMAIL, MENTOR_TYPE,
+                category.getMentoringCategoryId().categoryId(),
+                TITLE, SUBTITLE, DESCRIPTION,
+                DURATION, MentoringType.ONE_ON_ONE, Format.SINGLE,
+                SESSION_COUNT, MAX_PARTICIPANTS, false, PRICE, null,
+                List.of(sessionSlot(SESSION_DATE_1), sessionSlot(SESSION_DATE_2)),
+                List.of(timeSchedules(DayOfWeek.MONDAY), timeSchedules(DayOfWeek.WEDNESDAY))
+        );
+
+        UUID mentoringId = mentoringService.createMentoring(command);
+
+        em.flush();
+        em.clear();
+
+        Mentoring found = mentoringRepository.findById(new MentoringId(mentoringId)).orElseThrow();
+
+        log.info("==== 생성된 멘토링 ====");
+        log.info("id       : {}", found.getMentoringId().mentoringId());
+        log.info("title    : {}", found.getTitle());
+        log.info("status   : {}", found.getStatus());
+        log.info("price    : {}", found.getPrice());
+        log.info("duration : {}", found.getDuration());
+        log.info("mentor   : {} / {} / {}", found.getMentor().getName(), found.getMentor().getField(), found.getMentor().getEmail());
+        log.info("category : {} ({})", found.getMentoringCategory().getName(), found.getMentoringCategory().getCode());
+
+        log.info("==== 반복 패턴 ({}) ====", found.getRepeatPatterns().size());
+        found.getRepeatPatterns().forEach(p ->
+                log.info("  {} {} ~ {}", p.getDayOfWeek(), p.getStartTime(), p.getEndTime()));
+
+        log.info("==== 세션 ({}) ====", found.getSessions().size());
+        found.getSessions().forEach(s ->
+                log.info("  {} {} ~ {} [{}]", s.getSessionDate(), s.getSessionStartTime(), s.getSessionEndTime(), s.getStatus()));
+
+        assertThat(found.getTitle()).isEqualTo(TITLE);
+        assertThat(found.getStatus()).isEqualTo(MentoringStatus.INACTIVE);
+        assertThat(found.getRepeatPatterns()).hasSize(2);
+        assertThat(found.getSessions()).hasSize(2);
+    }
+}

--- a/src/test/java/com/goggles/mentoring_service/application/service/MentoringServiceTest.java
+++ b/src/test/java/com/goggles/mentoring_service/application/service/MentoringServiceTest.java
@@ -1,0 +1,82 @@
+package com.goggles.mentoring_service.application.service;
+
+import com.goggles.mentoring_service.application.command.MentoringCommand;
+import com.goggles.mentoring_service.domain.category.MentoringCategory;
+import com.goggles.mentoring_service.domain.category.MentoringCategoryId;
+import com.goggles.mentoring_service.domain.category.exception.CategoryNotFoundException;
+import com.goggles.mentoring_service.domain.category.repository.MentoringCategoryRepository;
+import com.goggles.mentoring_service.domain.mentoring.Format;
+import com.goggles.mentoring_service.domain.mentoring.MentoringType;
+import com.goggles.mentoring_service.domain.mentoring.repository.MentoringRepository;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.DayOfWeek;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+import static com.goggles.mentoring_service.domain.mentoring.MentoringFixture.*;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class MentoringServiceTest {
+
+    @InjectMocks
+    private MentoringService mentoringService;
+
+    @Mock
+    private MentoringRepository mentoringRepository;
+
+    @Mock
+    private MentoringCategoryRepository categoryRepository;
+
+    @Mock
+    private MentoringCategory category;
+
+    @Mock
+    private MentoringCategoryId mockCategoryId;
+
+    @Test
+    void createMentoring_success() {
+        given(categoryRepository.findById(any())).willReturn(Optional.of(category));
+        given(category.getMentoringCategoryId()).willReturn(mockCategoryId);
+        given(mockCategoryId.categoryId()).willReturn(CATEGORY_ID);
+        given(category.getName()).willReturn(CATEGORY_NAME);
+        given(category.getCode()).willReturn(CATEGORY_CODE);
+
+        UUID result = mentoringService.createMentoring(defaultCommand());
+
+        assertThat(result).isNotNull();
+        verify(mentoringRepository).save(any());
+    }
+
+    @Test
+    void createMentoring_category_not_found() {
+        given(categoryRepository.findById(any())).willReturn(Optional.empty());
+
+        assertThatThrownBy(() -> mentoringService.createMentoring(defaultCommand()))
+                .isInstanceOf(CategoryNotFoundException.class);
+    }
+
+    private MentoringCommand.Create defaultCommand() {
+        return new MentoringCommand.Create(
+                MENTOR_ID, MENTOR_NAME, MENTOR_FIELD, MENTOR_EMAIL, MENTOR_TYPE,
+                CATEGORY_ID,
+                TITLE, SUBTITLE, DESCRIPTION,
+                DURATION,
+                MentoringType.ONE_ON_ONE,
+                Format.SINGLE,
+                SESSION_COUNT, MAX_PARTICIPANTS, false, PRICE, null,
+                List.of(sessionSlot(SESSION_DATE_1)),
+                List.of(timeSchedules(DayOfWeek.MONDAY))
+        );
+    }
+}

--- a/src/test/java/com/goggles/mentoring_service/config/TestAuditConfig.java
+++ b/src/test/java/com/goggles/mentoring_service/config/TestAuditConfig.java
@@ -1,0 +1,17 @@
+package com.goggles.mentoring_service.config;
+
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.data.domain.AuditorAware;
+
+import java.util.Optional;
+import java.util.UUID;
+
+@TestConfiguration
+public class TestAuditConfig {
+
+    @Bean
+    public AuditorAware<UUID> auditorAware() {
+        return () -> Optional.of(UUID.fromString("00000000-0000-0000-0000-000000000001"));
+    }
+}

--- a/src/test/java/com/goggles/mentoring_service/domain/mentoring/MentoringFixture.java
+++ b/src/test/java/com/goggles/mentoring_service/domain/mentoring/MentoringFixture.java
@@ -1,0 +1,79 @@
+package com.goggles.mentoring_service.domain.mentoring;
+
+import com.goggles.mentoring_service.application.command.SessionSlot;
+import com.goggles.mentoring_service.application.command.TimeSchedules;
+import com.goggles.mentoring_service.domain.common.UserType;
+
+import java.time.DayOfWeek;
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.util.List;
+import java.util.UUID;
+
+public class MentoringFixture {
+
+    public static final UUID MENTOR_ID = UUID.fromString("00000000-0000-0000-0000-000000000001");
+    public static final String MENTOR_NAME = "홍길동";
+    public static final String MENTOR_FIELD = "백엔드";
+    public static final String MENTOR_EMAIL = "mentor@test.com";
+    public static final UserType MENTOR_TYPE = UserType.INSTRUCTOR;
+
+    public static final UUID CATEGORY_ID = UUID.fromString("00000000-0000-0000-0000-000000000002");
+    public static final String CATEGORY_NAME = "자바";
+    public static final String CATEGORY_CODE = "JAVA";
+
+    public static final String TITLE = "스프링 부트 멘토링";
+    public static final String SUBTITLE = "실무 위주";
+    public static final String DESCRIPTION = "멘토링 설명";
+    public static final MentoringDuration DURATION = MentoringDuration.MINUTES_60;
+    public static final int SESSION_COUNT = 1;
+    public static final int MAX_PARTICIPANTS = 1;
+    public static final int PRICE = 50_000;
+
+    public static final LocalDate SESSION_DATE_1 = LocalDate.of(2026, 5, 1);
+    public static final LocalDate SESSION_DATE_2 = LocalDate.of(2026, 5, 2);
+    public static final LocalTime START_TIME = LocalTime.of(10, 0);
+    public static final LocalTime END_TIME = LocalTime.of(11, 0);
+
+    public static Mentoring.MentoringBuilder defaultMentoringBuilder() {
+        return Mentoring.builder()
+                .mentorId(MENTOR_ID)
+                .mentorName(MENTOR_NAME)
+                .mentorField(MENTOR_FIELD)
+                .mentorEmail(MENTOR_EMAIL)
+                .mentorType(MENTOR_TYPE)
+                .categoryId(CATEGORY_ID)
+                .categoryName(CATEGORY_NAME)
+                .categoryCode(CATEGORY_CODE)
+                .title(TITLE)
+                .subtitle(SUBTITLE)
+                .description(DESCRIPTION)
+                .duration(DURATION)
+                .status(MentoringStatus.INACTIVE)
+                .mentoringType(MentoringType.ONE_ON_ONE)
+                .format(Format.SINGLE)
+                .sessionCount(SESSION_COUNT)
+                .maxParticipants(MAX_PARTICIPANTS)
+                .excludeHolidays(false)
+                .price(PRICE)
+                .endDate(null)
+                .sessions(List.of())
+                .repeatPatterns(List.of());
+    }
+
+    public static MentoringSession session(LocalDate date) {
+        return MentoringSession.of(date, START_TIME, END_TIME);
+    }
+
+    public static SessionSlot sessionSlot(LocalDate date) {
+        return new SessionSlot(date, START_TIME, END_TIME);
+    }
+
+    public static RepeatPattern repeatPattern(DayOfWeek dayOfWeek) {
+        return RepeatPattern.of(dayOfWeek, START_TIME, END_TIME);
+    }
+
+    public static TimeSchedules timeSchedules(DayOfWeek dayOfWeek) {
+        return new TimeSchedules(dayOfWeek, START_TIME, END_TIME);
+    }
+}

--- a/src/test/java/com/goggles/mentoring_service/domain/mentoring/MentoringTest.java
+++ b/src/test/java/com/goggles/mentoring_service/domain/mentoring/MentoringTest.java
@@ -1,0 +1,196 @@
+package com.goggles.mentoring_service.domain.mentoring;
+
+import com.goggles.mentoring_service.domain.mentoring.exception.MentoringPolicyViolationException;
+import com.goggles.mentoring_service.domain.mentoring.exception.RepeatPatternRequiredException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.time.DayOfWeek;
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.util.List;
+
+import static com.goggles.mentoring_service.domain.mentoring.MentoringFixture.*;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class MentoringTest {
+
+    private Mentoring mentoring;
+
+    @BeforeEach
+    void setUp() {
+        mentoring = defaultMentoringBuilder().build();
+    }
+
+    @Test
+    void create_success() {
+        assertThat(mentoring.getMentoringId()).isNotNull();
+        assertThat(mentoring.getStatus()).isEqualTo(MentoringStatus.INACTIVE);
+        assertThat(mentoring.getRepeatPatterns()).isEmpty();
+        assertThat(mentoring.getSessions()).isEmpty();
+    }
+
+    @Test
+    void create_negative_price() {
+        assertThatThrownBy(() -> defaultMentoringBuilder().price(-1).build())
+                .isInstanceOf(MentoringPolicyViolationException.class);
+    }
+
+    @Test
+    void create_group_min_participants() {
+        assertThatThrownBy(() -> defaultMentoringBuilder()
+                .mentoringType(MentoringType.GROUP)
+                .maxParticipants(1)
+                .build())
+                .isInstanceOf(MentoringPolicyViolationException.class);
+    }
+
+    @Test
+    void create_one_on_one_max_participants() {
+        assertThatThrownBy(() -> defaultMentoringBuilder()
+                .mentoringType(MentoringType.ONE_ON_ONE)
+                .maxParticipants(2)
+                .build())
+                .isInstanceOf(MentoringPolicyViolationException.class);
+    }
+
+    @Test
+    void create_multi_requires_min_2_sessions() {
+        assertThatThrownBy(() -> defaultMentoringBuilder()
+                .format(Format.MULTI)
+                .sessionCount(1)
+                .build())
+                .isInstanceOf(MentoringPolicyViolationException.class);
+    }
+
+    @Test
+    void addSessions_success() {
+        mentoring.addSessions(List.of(session(SESSION_DATE_1), session(SESSION_DATE_2)));
+
+        assertThat(mentoring.getSessions()).hasSize(2);
+        assertThat(mentoring.getSessions().getFirst().getStatus()).isEqualTo(SessionStatus.AVAILABLE);
+    }
+
+    @Test
+    void updateRepeatPatterns_success() {
+        mentoring.updateRepeatPatterns(List.of(
+                repeatPattern(DayOfWeek.MONDAY),
+                repeatPattern(DayOfWeek.WEDNESDAY)
+        ));
+
+        assertThat(mentoring.getRepeatPatterns()).hasSize(2);
+        assertThat(mentoring.getRepeatPatterns().getFirst().getDayOfWeek()).isEqualTo(DayOfWeek.MONDAY);
+    }
+
+    @Test
+    void updateRepeatPatterns_replaces_all() {
+        mentoring.updateRepeatPatterns(List.of(repeatPattern(DayOfWeek.MONDAY)));
+        mentoring.updateRepeatPatterns(List.of(repeatPattern(DayOfWeek.FRIDAY)));
+
+        assertThat(mentoring.getRepeatPatterns()).hasSize(1);
+        assertThat(mentoring.getRepeatPatterns().getFirst().getDayOfWeek()).isEqualTo(DayOfWeek.FRIDAY);
+    }
+
+    @Test
+    void addSessions_outside_business_hours() {
+        MentoringSession earlySession = MentoringSession.of(
+                SESSION_DATE_1, LocalTime.of(5, 0), LocalTime.of(6, 0));
+
+        assertThatThrownBy(() -> mentoring.addSessions(List.of(earlySession)))
+                .isInstanceOf(MentoringPolicyViolationException.class);
+    }
+
+    @Test
+    void addSessions_duration_mismatch() {
+        MentoringSession wrongDuration = MentoringSession.of(
+                SESSION_DATE_1, LocalTime.of(10, 0), LocalTime.of(10, 30));
+
+        assertThatThrownBy(() -> mentoring.addSessions(List.of(wrongDuration)))
+                .isInstanceOf(MentoringPolicyViolationException.class);
+    }
+
+    @Test
+    void addSessions_beyond_end_date() {
+        Mentoring withEndDate = defaultMentoringBuilder()
+                .endDate(LocalDate.of(2026, 4, 30))
+                .build();
+        MentoringSession lateSession = MentoringSession.of(
+                LocalDate.of(2026, 5, 1), START_TIME, END_TIME);
+
+        assertThatThrownBy(() -> withEndDate.addSessions(List.of(lateSession)))
+                .isInstanceOf(MentoringPolicyViolationException.class);
+    }
+
+    @Test
+    void generateSessions_success() {
+        Mentoring multiMentoring = defaultMentoringBuilder()
+                .format(Format.MULTI)
+                .sessionCount(2)
+                .build();
+        multiMentoring.updateRepeatPatterns(List.of(repeatPattern(DayOfWeek.MONDAY)));
+
+        // 2026-05-01(금) ~ 2026-05-31(일), 월요일: 5/4, 5/11, 5/18, 5/25 → 4개
+        List<MentoringSession> generated = multiMentoring.generateSessions(
+                LocalDate.of(2026, 5, 1),
+                LocalDate.of(2026, 5, 31),
+                date -> false
+        );
+
+        assertThat(generated).hasSize(4);
+        assertThat(generated.get(0).getSessionDate()).isEqualTo(LocalDate.of(2026, 5, 4));
+    }
+
+    @Test
+    void generateSessions_excludes_holidays() {
+        Mentoring multiMentoring = defaultMentoringBuilder()
+                .format(Format.MULTI)
+                .sessionCount(2)
+                .excludeHolidays(true)
+                .build();
+        multiMentoring.updateRepeatPatterns(List.of(repeatPattern(DayOfWeek.TUESDAY)));
+
+        // 5/5(어린이날, 화), 5/12, 5/19, 5/26 중 5/5 제외 → 3개
+        List<MentoringSession> generated = multiMentoring.generateSessions(
+                LocalDate.of(2026, 5, 1),
+                LocalDate.of(2026, 5, 31),
+                date -> date.equals(LocalDate.of(2026, 5, 5))
+        );
+
+        assertThat(generated).hasSize(3);
+        assertThat(generated).noneMatch(s -> s.getSessionDate().equals(LocalDate.of(2026, 5, 5)));
+    }
+
+    @Test
+    void generateSessions_only_for_multi_format() {
+        assertThatThrownBy(() -> mentoring.generateSessions(
+                SESSION_DATE_1, SESSION_DATE_2, date -> false))
+                .isInstanceOf(MentoringPolicyViolationException.class);
+    }
+
+    @Test
+    void activate_multi_requires_repeat_patterns() {
+        Mentoring multiMentoring = defaultMentoringBuilder()
+                .format(Format.MULTI)
+                .sessionCount(2)
+                .build();
+
+        assertThatThrownBy(multiMentoring::activate)
+                .isInstanceOf(RepeatPatternRequiredException.class);
+    }
+
+    @Test
+    void activate_success() {
+        mentoring.activate();
+
+        assertThat(mentoring.getStatus()).isEqualTo(MentoringStatus.ACTIVE);
+    }
+
+    @Test
+    void deactivate_success() {
+        mentoring.activate();
+        mentoring.deactivate();
+
+        assertThat(mentoring.getStatus()).isEqualTo(MentoringStatus.INACTIVE);
+    }
+}

--- a/src/test/java/com/goggles/mentoring_service/presentation/MentoringControllerTest.java
+++ b/src/test/java/com/goggles/mentoring_service/presentation/MentoringControllerTest.java
@@ -1,0 +1,86 @@
+package com.goggles.mentoring_service.presentation;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.goggles.mentoring_service.application.service.MentoringService;
+import com.goggles.mentoring_service.domain.mentoring.Format;
+import com.goggles.mentoring_service.domain.mentoring.MentoringType;
+import com.goggles.mentoring_service.infrastructure.config.WebMvcConfig;
+import com.goggles.mentoring_service.presentation.dto.MentoringRequest;
+import com.goggles.mentoring_service.presentation.support.UserContextArgumentResolver;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.data.jpa.mapping.JpaMetamodelMappingContext;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.UUID;
+
+import java.util.List;
+
+import static com.goggles.mentoring_service.domain.mentoring.MentoringFixture.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(MentoringController.class)
+@Import({WebMvcConfig.class, UserContextArgumentResolver.class})
+@MockitoBean(types = JpaMetamodelMappingContext.class)
+class MentoringControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @MockitoBean
+    private MentoringService mentoringService;
+
+    @Test
+    void createMentoring_success() throws Exception {
+        UUID mentoringId = UUID.randomUUID();
+        given(mentoringService.createMentoring(any())).willReturn(mentoringId);
+
+        mockMvc.perform(post("/api/v1/mentorings")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .headers(userHeaders())
+                        .content(objectMapper.writeValueAsString(defaultRequest())))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.mentoringId").value(mentoringId.toString()));
+    }
+
+    @Test
+    void createMentoring_invalid_request() throws Exception {
+        mockMvc.perform(post("/api/v1/mentorings")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .headers(userHeaders())
+                        .content("{}"))
+                .andExpect(status().isBadRequest());
+    }
+
+    private HttpHeaders userHeaders() {
+        HttpHeaders headers = new HttpHeaders();
+        headers.add("X-User-Id", MENTOR_ID.toString());
+        headers.add("X-User-Type", MENTOR_TYPE.name());
+        headers.add("X-User-Name", MENTOR_NAME);
+        headers.add("X-User-Email", MENTOR_EMAIL);
+        headers.add("X-User-Field", MENTOR_FIELD);
+        return headers;
+    }
+
+    private MentoringRequest.Create defaultRequest() {
+        return new MentoringRequest.Create(
+                CATEGORY_ID, TITLE, SUBTITLE, DESCRIPTION,
+                DURATION, MentoringType.ONE_ON_ONE, Format.SINGLE,
+                SESSION_COUNT, MAX_PARTICIPANTS, false, PRICE, null,
+                List.of(new MentoringRequest.Create.SessionDto(SESSION_DATE_1, START_TIME, END_TIME)),
+                List.of(new MentoringRequest.Create.RepeatPatternDto(java.time.DayOfWeek.MONDAY, START_TIME, END_TIME))
+        );
+    }
+}

--- a/src/test/resources/application-test.yaml
+++ b/src/test/resources/application-test.yaml
@@ -7,9 +7,12 @@ spring:
   jpa:
     hibernate:
       ddl-auto: create-drop
+    show-sql: true
     properties:
       hibernate:
         dialect: org.hibernate.dialect.H2Dialect
+        default_schema:
+        format_sql: true
 
 management:
   tracing:


### PR DESCRIPTION
### 📌 관련 이슈
- close #14 

### 💡 작업 내용  
 - `BookingType` → `Format(SINGLE/MULTI)`으로 단순화
 - 도메인 → Application 역방향 의존 제거 (`RepeatPattern`, `MentoringSession`이 Command 타입 참조하던 구조 해소) 
 - 세션 유효성 검증 도메인화: 업무시간(06:00~22:00), duration 일치, endDate 초과 체크 
  - `HolidayProvider` 인터페이스 + `HolidayProviderImpl` (양력 고정 공휴일) 추가 
  - `Format.MULTI`일 때 `generateSessions()` 반복 패턴 기반 세션 자동 생성 
  - `Format.MULTI` 활성화 시 RepeatPattern 필수 검증 복구
  - `UserContext`를 `ArgumentResolver`로 헤더에서 추출해 컨트롤러에 주입
  - 도메인 단위 테스트, 서비스 단위/통합 테스트, 컨트롤러 테스트 작성  

### 🔍 변경 이유
  - 멘토링 생성 기능 신규 개발                                                                       
  - 기존 패키지 구조가 도메인 경계 없이 평탄해 응집도가 낮았고, Domain이 Application 타입을 참조하는 의존성 역전 문제가 있어 함께 정리   

### 📝 리뷰 포인트 (선택)
  - `MentoringCommand.toMentoring()` 안에서 `RepeatPattern`, `MentoringSession` 변환 담당 — Application → Domain 방향이 맞는지 확인 부탁 
  - `generateSessions()`는 `Format.MULTI`에서만 호출 가능하도록 가드 추가했는데, 추후 스케줄러 연동 방식과 맞는지 검토 필요

### 🧠 기타 참고 사항
  - `HolidayProviderImpl`은 양력 고정 공휴일만 처리 (음력 기반 공휴일은 외부 API 연동 시 추가 예정)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# 릴리스 노트

* **New Features**
  * 멘토링 세션 생성 기능 추가
  * 일회성 및 반복 멘토링 형식 지원
  * 휴일 자동 제외 기능
  * 업무 시간(오전 6시~오후 10시) 내 세션 예약 강제

* **Tests**
  * 통합 및 단위 테스트 추가
  * 테스트 데이터베이스 설정 개선

<!-- end of auto-generated comment: release notes by coderabbit.ai -->