### PR TITLE
[FEAT] 멘토링 예약 생성 

### DIFF
--- a/src/main/java/com/goggles/mentoring_service/application/command/BookingCommand.java
+++ b/src/main/java/com/goggles/mentoring_service/application/command/BookingCommand.java
@@ -1,0 +1,19 @@
+package com.goggles.mentoring_service.application.command;
+
+import com.goggles.mentoring_service.domain.booking.MentoringBookingId;
+import com.goggles.mentoring_service.domain.booking.SessionSlot;
+import java.util.List;
+import java.util.UUID;
+
+public class BookingCommand {
+  public record Create(
+      MenteeInfo menteeInfo,
+      UUID mentoringId,
+      List<SessionSlot> sessionSlots,
+      String requestMessage,
+      UUID orderId) {}
+
+  public record PaymentFailed(
+          MentoringBookingId mentoringBookingId, UUID orderId, String failureReason
+  ) {}
+}

--- a/src/main/java/com/goggles/mentoring_service/application/command/MenteeInfo.java
+++ b/src/main/java/com/goggles/mentoring_service/application/command/MenteeInfo.java
@@ -1,0 +1,6 @@
+package com.goggles.mentoring_service.application.command;
+
+import com.goggles.mentoring_service.domain._common.UserType;
+import java.util.UUID;
+
+public record MenteeInfo(UUID menteeId, UserType menteeUserType, String menteeName) {}

--- a/src/main/java/com/goggles/mentoring_service/application/command/MentoringCommand.java
+++ b/src/main/java/com/goggles/mentoring_service/application/command/MentoringCommand.java
@@ -1,6 +1,7 @@
 package com.goggles.mentoring_service.application.command;
 
 import com.goggles.mentoring_service.domain._common.UserType;
+import com.goggles.mentoring_service.domain.booking.SessionSlot;
 import com.goggles.mentoring_service.domain.category.MentoringCategory;
 import com.goggles.mentoring_service.domain.mentoring.*;
 

--- a/src/main/java/com/goggles/mentoring_service/application/result/BookingResult.java
+++ b/src/main/java/com/goggles/mentoring_service/application/result/BookingResult.java
@@ -1,0 +1,14 @@
+package com.goggles.mentoring_service.application.result;
+
+import com.goggles.mentoring_service.domain.booking.MentoringBookingId;
+import java.util.UUID;
+
+public class BookingResult {
+
+  public record Create(UUID bookingId) {
+
+    public static Create of(MentoringBookingId mentoringBookingId) {
+      return new Create(mentoringBookingId.bookingId());
+    }
+  }
+}

--- a/src/main/java/com/goggles/mentoring_service/application/result/BookingResult.java
+++ b/src/main/java/com/goggles/mentoring_service/application/result/BookingResult.java
@@ -1,14 +1,24 @@
 package com.goggles.mentoring_service.application.result;
 
-import com.goggles.mentoring_service.domain.booking.MentoringBookingId;
+import com.goggles.mentoring_service.domain.booking.MentoringBooking;
+import com.goggles.mentoring_service.domain.mentoring.Mentoring;
+
 import java.util.UUID;
 
 public class BookingResult {
 
-  public record Create(UUID bookingId) {
+  public record Create(UUID enrollmentId, UUID productId, String productName, long productPrice,
+                       UUID instructorId, String instructorName) {
 
-    public static Create of(MentoringBookingId mentoringBookingId) {
-      return new Create(mentoringBookingId.bookingId());
+    public static Create of(MentoringBooking booking, Mentoring mentoring){
+        return new Create(
+            booking.getMentoringBookingId().bookingId(),
+            mentoring.getMentoringId().mentoringId(),
+            mentoring.getTitle(),
+            mentoring.getPrice(),
+            mentoring.getMentor().getId(),
+            mentoring.getMentor().getName()
+        );
     }
   }
 }

--- a/src/main/java/com/goggles/mentoring_service/application/result/MentoringResult.java
+++ b/src/main/java/com/goggles/mentoring_service/application/result/MentoringResult.java
@@ -13,7 +13,7 @@ public class MentoringResult {
 	public record Detail(UUID mentoringId, String title, String subtitle, String description,
 						 MentorInfo mentor, CategoryInfo category, MentoringStatus status,
 						 Format format, MentoringType mentoringType, MentoringDuration duration,
-						 int sessionCount, int maxParticipants, boolean excludeHolidays, int price,
+						 int sessionCount, int maxParticipants, boolean excludeHolidays, long price,
 						 LocalDate endDate) {
 		public static Detail from(Mentoring m) {
 			return new Detail(m.getMentoringId()
@@ -56,7 +56,7 @@ public class MentoringResult {
 
 	public record Summary(UUID mentoringId, String title, String subtitle, String mentorName,
 						  String categoryName, MentoringType mentoringType, Format format,
-						  int price, MentoringStatus status) {
+						  long price, MentoringStatus status) {
 		public static Summary from(Mentoring m) {
 			return new Summary(m.getMentoringId()
 					.mentoringId(), m.getTitle(), m.getSubtitle(), m.getMentor()

--- a/src/main/java/com/goggles/mentoring_service/application/service/BookingService.java
+++ b/src/main/java/com/goggles/mentoring_service/application/service/BookingService.java
@@ -1,11 +1,43 @@
 package com.goggles.mentoring_service.application.service;
 
+import com.goggles.mentoring_service.application.command.BookingCommand;
+import com.goggles.mentoring_service.application.command.MenteeInfo;
+import com.goggles.mentoring_service.application.result.BookingResult;
+import com.goggles.mentoring_service.domain.booking.MentoringBooking;
+import com.goggles.mentoring_service.domain.booking.SessionSlot;
+import com.goggles.mentoring_service.domain.booking.exception.BookingNotFoundException;
 import com.goggles.mentoring_service.domain.booking.repository.MentoringBookingRepository;
+import com.goggles.mentoring_service.domain.mentoring.Mentoring;
+import com.goggles.mentoring_service.domain.mentoring.MentoringId;
+import com.goggles.mentoring_service.domain.mentoring.exception.MentoringNotFoundException;
+import com.goggles.mentoring_service.domain.mentoring.repository.MentoringRepository;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
 public class BookingService {
-	private final MentoringBookingRepository bookingRepository;
+  private final MentoringBookingRepository bookingRepository;
+  private final MentoringRepository mentoringRepository;
+
+  @Transactional
+  public BookingResult.Create createBooking(BookingCommand.Create command) {
+    MentoringId mentoringId = new MentoringId(command.mentoringId());
+    Mentoring mentoring =
+        mentoringRepository
+            .findById(mentoringId)
+            .orElseThrow(() -> new MentoringNotFoundException(mentoringId));
+
+    MenteeInfo menteeInfo = command.menteeInfo();
+    List<SessionSlot> slots = command.sessionSlots();
+    mentoring.bookSession(slots);
+    MentoringBooking booking =
+        MentoringBooking.create(
+            menteeInfo.menteeId(), menteeInfo.menteeUserType(), menteeInfo.menteeName(),
+            mentoring, slots, command.requestMessage(), command.orderId());
+    bookingRepository.save(booking);
+    return BookingResult.Create.of(booking.getMentoringBookingId());
+  }
 }

--- a/src/main/java/com/goggles/mentoring_service/application/service/BookingService.java
+++ b/src/main/java/com/goggles/mentoring_service/application/service/BookingService.java
@@ -11,6 +11,9 @@ import com.goggles.mentoring_service.domain.mentoring.Mentoring;
 import com.goggles.mentoring_service.domain.mentoring.MentoringId;
 import com.goggles.mentoring_service.domain.mentoring.exception.MentoringNotFoundException;
 import com.goggles.mentoring_service.domain.mentoring.repository.MentoringRepository;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -41,11 +44,12 @@ public class BookingService {
     return BookingResult.Create.of(booking.getMentoringBookingId());
   }
 
+  @Transactional
   public void paymentFailed(BookingCommand.PaymentFailed command) {
     MentoringBooking booking =
             bookingRepository.findById(command.mentoringBookingId())
                     .orElseThrow(() -> new BookingNotFoundException(command.mentoringBookingId()));
-    booking.failPayment(command.failureReason());
+    booking.failPayment(command.failureReason(), LocalDateTime.now());
     bookingRepository.save(booking);
   }
 }

--- a/src/main/java/com/goggles/mentoring_service/application/service/BookingService.java
+++ b/src/main/java/com/goggles/mentoring_service/application/service/BookingService.java
@@ -41,7 +41,7 @@ public class BookingService {
             menteeInfo.menteeId(), menteeInfo.menteeUserType(), menteeInfo.menteeName(),
             mentoring, slots, command.requestMessage(), command.orderId());
     bookingRepository.save(booking);
-    return BookingResult.Create.of(booking.getMentoringBookingId());
+    return BookingResult.Create.of(booking, mentoring);
   }
 
   @Transactional

--- a/src/main/java/com/goggles/mentoring_service/application/service/BookingService.java
+++ b/src/main/java/com/goggles/mentoring_service/application/service/BookingService.java
@@ -40,4 +40,12 @@ public class BookingService {
     bookingRepository.save(booking);
     return BookingResult.Create.of(booking.getMentoringBookingId());
   }
+
+  public void paymentFailed(BookingCommand.PaymentFailed command) {
+    MentoringBooking booking =
+            bookingRepository.findById(command.mentoringBookingId())
+                    .orElseThrow(() -> new BookingNotFoundException(command.mentoringBookingId()));
+    booking.failPayment(command.failureReason());
+    bookingRepository.save(booking);
+  }
 }

--- a/src/main/java/com/goggles/mentoring_service/application/service/BookingService.java
+++ b/src/main/java/com/goggles/mentoring_service/application/service/BookingService.java
@@ -1,0 +1,11 @@
+package com.goggles.mentoring_service.application.service;
+
+import com.goggles.mentoring_service.domain.booking.repository.MentoringBookingRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class BookingService {
+	private final MentoringBookingRepository bookingRepository;
+}

--- a/src/main/java/com/goggles/mentoring_service/domain/booking/BookedMentoring.java
+++ b/src/main/java/com/goggles/mentoring_service/domain/booking/BookedMentoring.java
@@ -1,5 +1,6 @@
 package com.goggles.mentoring_service.domain.booking;
 
+import com.goggles.mentoring_service.domain.mentoring.Mentoring;
 import jakarta.persistence.Column;
 import jakarta.persistence.Embeddable;
 import lombok.AccessLevel;
@@ -8,8 +9,6 @@ import lombok.NoArgsConstructor;
 import org.hibernate.annotations.JdbcTypeCode;
 import org.hibernate.type.SqlTypes;
 
-import java.time.LocalDate;
-import java.time.LocalTime;
 import java.util.UUID;
 
 @Embeddable
@@ -31,14 +30,20 @@ public class BookedMentoring {
 	private UUID mentorId;
 	private String mentorName;
 
-	private LocalDate sessionDate;
-	private LocalTime sessionStartTime;
-	private LocalTime sessionEndTime;
-
+	static BookedMentoring of(Mentoring mentoring) {
+		BookedMentoring bookedMentoring = new BookedMentoring();
+		bookedMentoring.mentoringId = mentoring.getMentoringId().mentoringId();
+		bookedMentoring.categoryCode = mentoring.getMentoringCategory().getCode();
+		bookedMentoring.categoryName = mentoring.getMentoringCategory().getName();
+		bookedMentoring.title = mentoring.getTitle();
+		bookedMentoring.subtitle = mentoring.getSubtitle();
+		bookedMentoring.mentorId = mentoring.getMentor().getId();
+		bookedMentoring.mentorName = mentoring.getMentor().getName();
+		return bookedMentoring;
+	}
 
 	static BookedMentoring of(UUID mentoringId, String categoryCode, String categoryName,
-			String title, String subtitle, UUID mentorId, String mentorName, LocalDate sessionDate,
-			LocalTime sessionStartTime, LocalTime sessionEndTime) {
+			String title, String subtitle, UUID mentorId, String mentorName) {
 		BookedMentoring bookedMentoring = new BookedMentoring();
 		bookedMentoring.mentoringId = mentoringId;
 		bookedMentoring.categoryCode = categoryCode;
@@ -47,9 +52,6 @@ public class BookedMentoring {
 		bookedMentoring.subtitle = subtitle;
 		bookedMentoring.mentorId = mentorId;
 		bookedMentoring.mentorName = mentorName;
-		bookedMentoring.sessionDate = sessionDate;
-		bookedMentoring.sessionStartTime = sessionStartTime;
-		bookedMentoring.sessionEndTime = sessionEndTime;
 		return bookedMentoring;
 	}
 

--- a/src/main/java/com/goggles/mentoring_service/domain/booking/BookedTime.java
+++ b/src/main/java/com/goggles/mentoring_service/domain/booking/BookedTime.java
@@ -1,0 +1,26 @@
+package com.goggles.mentoring_service.domain.booking;
+
+import jakarta.persistence.Embeddable;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+
+@Embeddable
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class BookedTime {
+	private LocalDate sessionDate;
+	private LocalTime sessionStartTime;
+	private LocalTime sessionEndTime;
+
+	public static BookedTime of(SessionSlot slot) {
+		BookedTime bookedTime = new BookedTime();
+		bookedTime.sessionDate = slot.date();
+		bookedTime.sessionStartTime = slot.startTime();
+		bookedTime.sessionEndTime = slot.endTime();
+		return bookedTime;
+	}
+}

--- a/src/main/java/com/goggles/mentoring_service/domain/booking/Mentee.java
+++ b/src/main/java/com/goggles/mentoring_service/domain/booking/Mentee.java
@@ -25,7 +25,7 @@ public class Mentee {
 	@Column(name = "student_name", length = 100, nullable = false)
 	private String name;
 
-	static Mentee of(UUID id, UserType type, String name) {
+	 static Mentee of(UUID id, UserType type, String name) {
 		validateUserType(id, type);
 		Mentee mentee = new Mentee();
 		mentee.id = id;
@@ -43,3 +43,4 @@ public class Mentee {
 		return this.id.equals(userId);
 	}
 }
+

--- a/src/main/java/com/goggles/mentoring_service/domain/booking/MentoringBooking.java
+++ b/src/main/java/com/goggles/mentoring_service/domain/booking/MentoringBooking.java
@@ -77,10 +77,10 @@ public class MentoringBooking extends BaseAudit {
     this.status = BookingStatus.PAYMENT_COMPLETED;
   }
 
-  public void failPayment(String failureReason) {
+  public void failPayment(String failureReason, LocalDateTime now) {
     validateStatus(BookingStatus.PAYMENT_FAILED);
     this.status = BookingStatus.PAYMENT_FAILED;
-    this.closure = BookingClosure.close(mentee.getId(), failureReason, LocalDateTime.now());
+    this.closure = BookingClosure.close(mentee.getId(), failureReason,now );
   }
 
   public void accept(UUID userId, UserType userType) {

--- a/src/main/java/com/goggles/mentoring_service/domain/booking/MentoringBooking.java
+++ b/src/main/java/com/goggles/mentoring_service/domain/booking/MentoringBooking.java
@@ -2,20 +2,19 @@ package com.goggles.mentoring_service.domain.booking;
 
 import com.goggles.common.domain.BaseAudit;
 import com.goggles.mentoring_service.domain._common.UserType;
+import com.goggles.mentoring_service.domain.mentoring.Mentoring;
 import com.goggles.mentoring_service.domain.booking.exception.CancellationDeadlineExceededException;
 import com.goggles.mentoring_service.domain.booking.exception.CancellationReasonRequiredException;
 import com.goggles.mentoring_service.domain.booking.exception.UnauthorizedBookingAccessException;
 import jakarta.persistence.*;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
 import lombok.AccessLevel;
-import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.SQLRestriction;
-
-import java.time.LocalDate;
-import java.time.LocalDateTime;
-import java.time.LocalTime;
-import java.util.UUID;
 
 @Getter
 @Entity
@@ -25,124 +24,137 @@ import java.util.UUID;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class MentoringBooking extends BaseAudit {
 
-	private static final int CANCELLATION_DEADLINE_HOURS = 24;
+  private static final int CANCELLATION_DEADLINE_HOURS = 24;
 
-	@EmbeddedId
-	private MentoringBookingId mentoringBookingId;
+  @EmbeddedId private MentoringBookingId mentoringBookingId;
 
-	@Embedded
-	private BookedMentoring bookedMentoring;
+  @Embedded private BookedMentoring bookedMentoring;
 
-	@Embedded
-	private Mentee mentee;
+  @Embedded private Mentee mentee;
 
-	@Enumerated(EnumType.STRING)
-	@Column(length = 30, nullable = false)
-	private BookingStatus status = BookingStatus.PENDING;
+  @ElementCollection
+  @CollectionTable(name = "P_BOOKED_TIME", joinColumns = @JoinColumn(name = "booking_id"))
+  private List<BookedTime> bookedTimes = new ArrayList<>();
 
-	@Embedded
-	private BookingClosure closure;
+  @Enumerated(EnumType.STRING)
+  @Column(length = 30, nullable = false)
+  private BookingStatus status = BookingStatus.PENDING;
 
-	private MentoringBooking(BookedMentoring bookedMentoring, Mentee mentee) {
-		this.mentoringBookingId = MentoringBookingId.of();
-		this.bookedMentoring = bookedMentoring;
-		this.mentee = mentee;
-	}
+  @Column(columnDefinition = "TEXT")
+  private String requestMessage;
 
-	@Builder
-	public static MentoringBooking create(UUID mentoringId, String categoryCode,
-			String categoryName, String title, String subtitle, UUID mentorId, String mentorName,
-			LocalDate sessionDate, LocalTime sessionStartTime, LocalTime sessionEndTime,
-			UUID menteeId, UserType menteeUserType, String menteeName) {
-		BookedMentoring bookedMentoring =
-				BookedMentoring.of(mentoringId, categoryCode, categoryName, title, subtitle,
-						mentorId, mentorName, sessionDate, sessionStartTime, sessionEndTime);
-		Mentee mentee = Mentee.of(menteeId, menteeUserType, menteeName);
-		return new MentoringBooking(bookedMentoring, mentee);
-	}
+  @Embedded private BookingClosure closure;
 
-	public void completePayment() {
-		validateStatus(BookingStatus.PAYMENT_COMPLETED);
-		this.status = BookingStatus.PAYMENT_COMPLETED;
-	}
+  private UUID orderId;
 
-	public void failPayment() {
-		validateStatus(BookingStatus.PAYMENT_FAILED);
-		this.status = BookingStatus.PAYMENT_FAILED;
-	}
+  private MentoringBooking(
+      BookedMentoring bookedMentoring,
+      Mentee mentee,
+      List<BookedTime> bookedTimes,
+      String requestMessage,
+          UUID orderId) {
+    this.mentoringBookingId = MentoringBookingId.of();
+    this.bookedMentoring = bookedMentoring;
+    this.mentee = mentee;
+    this.bookedTimes.addAll(bookedTimes);
+    this.requestMessage = requestMessage;
+    this.orderId = orderId;
+  }
 
-	public void accept(UUID userId, UserType userType) {
-		checkIfUserIsMentor(userId, userType);
-		validateStatus(BookingStatus.ACCEPTED);
-		this.status = BookingStatus.ACCEPTED;
-	}
+  public static MentoringBooking create(
+      UUID menteeId, UserType menteeUserType, String menteeName,
+      Mentoring mentoring,
+      List<SessionSlot> sessionSlots,
+      String requestMessage, UUID orderId) {
+    Mentee mentee = Mentee.of(menteeId, menteeUserType, menteeName);
+    BookedMentoring bookedMentoring = BookedMentoring.of(mentoring);
+    List<BookedTime> bookedTimes = sessionSlots.stream().map(BookedTime::of).toList();
+    return new MentoringBooking(bookedMentoring, mentee, bookedTimes, requestMessage, orderId);
+  }
 
-	public void reject(UUID userId, UserType userType, String reason, LocalDateTime now) {
-		checkIfUserIsMentor(userId, userType);
-		validateReason(reason);
-		validateStatus(BookingStatus.REJECTED);
-		this.status = BookingStatus.REJECTED;
-		this.closure = BookingClosure.close(userId, reason, now);
-	}
+  public void completePayment() {
+    validateStatus(BookingStatus.PAYMENT_COMPLETED);
+    this.status = BookingStatus.PAYMENT_COMPLETED;
+  }
 
-	public void cancel(UUID canceledBy, UserType userType, String reason, LocalDateTime now) {
-		validateReason(reason);
-		checkIfUserCanCancel(canceledBy, userType);
-		checkCancellationDeadline(now);
-		validateStatus(BookingStatus.CANCELED);
-		this.status = BookingStatus.CANCELED;
-		this.closure = BookingClosure.close(canceledBy, reason, now);
-	}
+  public void failPayment(String failureReason) {
+    validateStatus(BookingStatus.PAYMENT_FAILED);
+    this.status = BookingStatus.PAYMENT_FAILED;
+    this.closure = BookingClosure.close(mentee.getId(), failureReason, LocalDateTime.now());
+  }
 
-	public UUID getClosedBy() {
-		return this.closure != null ? this.closure.getClosedBy() : null;
-	}
+  public void accept(UUID userId, UserType userType) {
+    checkIfUserIsMentor(userId, userType);
+    validateStatus(BookingStatus.ACCEPTED);
+    this.status = BookingStatus.ACCEPTED;
+  }
 
-	public LocalDateTime getClosedAt() {
-		return this.closure != null ? this.closure.getClosedAt() : null;
-	}
+  public void reject(UUID userId, UserType userType, String reason, LocalDateTime now) {
+    checkIfUserIsMentor(userId, userType);
+    validateReason(reason);
+    validateStatus(BookingStatus.REJECTED);
+    this.status = BookingStatus.REJECTED;
+    this.closure = BookingClosure.close(userId, reason, now);
+  }
 
-	public String getCloseReason() {
-		return this.closure != null ? this.closure.getCloseReason() : null;
-	}
+  public void cancel(UUID canceledBy, UserType userType, String reason, LocalDateTime now) {
+    validateReason(reason);
+    checkIfUserCanCancel(canceledBy, userType);
+    checkCancellationDeadline(now);
+    validateStatus(BookingStatus.CANCELED);
+    this.status = BookingStatus.CANCELED;
+    this.closure = BookingClosure.close(canceledBy, reason, now);
+  }
 
-	private void checkIfUserIsMentor(UUID userId, UserType userType) {
-		if (userType != UserType.INSTRUCTOR || !bookedMentoring.isMentor(userId)) {
-			throw UnauthorizedBookingAccessException.noPermissionToProcess();
-		}
-	}
+  public UUID getClosedBy() {
+    return this.closure != null ? this.closure.getClosedBy() : null;
+  }
 
-	private void checkIfUserCanCancel(UUID canceledBy, UserType userType) {
-		if (userType == UserType.INSTRUCTOR) {
-			if (!bookedMentoring.isMentor(canceledBy)) {
-				throw UnauthorizedBookingAccessException.noPermissionToCancel();
-			}
-		}
-		else if (userType == UserType.STUDENT) {
-			if (!mentee.isMentee(canceledBy)) {
-				throw UnauthorizedBookingAccessException.noPermissionToCancel();
-			}
-		}
-		else {
-			throw UnauthorizedBookingAccessException.noPermissionToCancel();
-		}
-	}
+  public LocalDateTime getClosedAt() {
+    return this.closure != null ? this.closure.getClosedAt() : null;
+  }
 
-	private void validateReason(String reason) {
-		if (reason == null || reason.isBlank()) {
-			throw CancellationReasonRequiredException.of();
-		}
-	}
+  public String getCloseReason() {
+    return this.closure != null ? this.closure.getCloseReason() : null;
+  }
 
-	private void checkCancellationDeadline(LocalDateTime now) {
-		LocalDateTime sessionStart = LocalDateTime.of(bookedMentoring.getSessionDate(),
-				bookedMentoring.getSessionStartTime());
-		if (now.isAfter(sessionStart.minusHours(CANCELLATION_DEADLINE_HOURS))) {
-			throw CancellationDeadlineExceededException.of();
-		}
-	}
+  private void checkIfUserIsMentor(UUID userId, UserType userType) {
+    if (userType != UserType.INSTRUCTOR || !bookedMentoring.isMentor(userId)) {
+      throw UnauthorizedBookingAccessException.noPermissionToProcess();
+    }
+  }
 
-	private void validateStatus(BookingStatus transitionTo) {
-		this.status.checkTransitionValidation(transitionTo);
-	}
+  private void checkIfUserCanCancel(UUID canceledBy, UserType userType) {
+    if (userType == UserType.INSTRUCTOR) {
+      if (!bookedMentoring.isMentor(canceledBy)) {
+        throw UnauthorizedBookingAccessException.noPermissionToCancel();
+      }
+    } else if (userType == UserType.STUDENT) {
+      if (!mentee.isMentee(canceledBy)) {
+        throw UnauthorizedBookingAccessException.noPermissionToCancel();
+      }
+    } else {
+      throw UnauthorizedBookingAccessException.noPermissionToCancel();
+    }
+  }
+
+  private void validateReason(String reason) {
+    if (reason == null || reason.isBlank()) {
+      throw CancellationReasonRequiredException.of();
+    }
+  }
+
+  private void checkCancellationDeadline(LocalDateTime now) {
+    for (BookedTime session : this.bookedTimes) {
+      LocalDateTime sessionStart =
+          LocalDateTime.of(session.getSessionDate(), session.getSessionStartTime());
+      if (now.isAfter(sessionStart.minusHours(CANCELLATION_DEADLINE_HOURS))) {
+        throw CancellationDeadlineExceededException.of();
+      }
+    }
+  }
+
+  private void validateStatus(BookingStatus transitionTo) {
+    this.status.checkTransitionValidation(transitionTo);
+  }
 }

--- a/src/main/java/com/goggles/mentoring_service/domain/booking/SessionSlot.java
+++ b/src/main/java/com/goggles/mentoring_service/domain/booking/SessionSlot.java
@@ -1,4 +1,4 @@
-package com.goggles.mentoring_service.application.command;
+package com.goggles.mentoring_service.domain.booking;
 
 import java.time.LocalDate;
 import java.time.LocalTime;

--- a/src/main/java/com/goggles/mentoring_service/domain/mentoring/Mentoring.java
+++ b/src/main/java/com/goggles/mentoring_service/domain/mentoring/Mentoring.java
@@ -77,13 +77,13 @@ public class Mentoring extends BaseAudit {
 	private boolean excludeHolidays = true;
 
 	@Column(nullable = false)
-	private int price;
+	private long price;
 
 
 	private Mentoring(Mentor mentor, Category mentoringCategory, String title, String subtitle,
 			String description, MentoringDuration duration, MentoringStatus status,
 			MentoringType mentoringType, Format format, int sessionCount, int maxParticipants,
-			boolean excludeHolidays, int price, LocalDate endDate,
+			boolean excludeHolidays, long price, LocalDate endDate,
 			List<RepeatPattern> repeatPatterns, List<MentoringSession> mentoringSessions) {
 		validateTypeConstraints(mentoringType, format, sessionCount, maxParticipants);
 		if (price < 0) {

--- a/src/main/java/com/goggles/mentoring_service/domain/mentoring/Mentoring.java
+++ b/src/main/java/com/goggles/mentoring_service/domain/mentoring/Mentoring.java
@@ -2,6 +2,7 @@ package com.goggles.mentoring_service.domain.mentoring;
 
 import com.goggles.common.domain.BaseAudit;
 import com.goggles.mentoring_service.domain._common.UserType;
+import com.goggles.mentoring_service.domain.booking.SessionSlot;
 import com.goggles.mentoring_service.domain.mentoring.exception.BookedSessionCannotBeDeletedException;
 import com.goggles.mentoring_service.domain.mentoring.exception.MentoringPolicyViolationException;
 import com.goggles.mentoring_service.domain.mentoring.exception.RepeatPatternRequiredException;
@@ -248,6 +249,10 @@ public class Mentoring extends BaseAudit {
 		findSession(date, startTime).book();
 	}
 
+	public void bookSession(List<SessionSlot> sessionSlots) {
+		sessionSlots.forEach(slot -> findSession(slot.date(), slot.startTime()).book());
+	}
+
 	private MentoringSession findSession(LocalDate date, LocalTime startTime) {
 		return this.sessions.stream()
 				.filter(session -> session.getSessionDate()
@@ -256,5 +261,4 @@ public class Mentoring extends BaseAudit {
 				.findFirst()
 				.orElseThrow(() -> new SessionNotFoundException(date, startTime));
 	}
-
 }

--- a/src/main/java/com/goggles/mentoring_service/domain/mentoring/Mentoring.java
+++ b/src/main/java/com/goggles/mentoring_service/domain/mentoring/Mentoring.java
@@ -250,7 +250,10 @@ public class Mentoring extends BaseAudit {
 	}
 
 	public void bookSession(List<SessionSlot> sessionSlots) {
-		sessionSlots.forEach(slot -> findSession(slot.date(), slot.startTime()).book());
+		List<MentoringSession> targets = sessionSlots.stream()
+				.map(slot -> findSession(slot.date(), slot.startTime()))
+				.toList();
+		targets.forEach(MentoringSession::book);
 	}
 
 	private MentoringSession findSession(LocalDate date, LocalTime startTime) {

--- a/src/main/java/com/goggles/mentoring_service/domain/mentoring/exception/InvalidConditionException.java
+++ b/src/main/java/com/goggles/mentoring_service/domain/mentoring/exception/InvalidConditionException.java
@@ -1,6 +1,7 @@
 package com.goggles.mentoring_service.domain.mentoring.exception;
 
-import com.goggles.mentoring_service.domain.common.MentoringValidationException;
+
+import com.goggles.mentoring_service.domain._common.MentoringValidationException;
 
 public class InvalidConditionException extends MentoringValidationException {
 	public InvalidConditionException(String message) {

--- a/src/main/java/com/goggles/mentoring_service/infrastructure/persistence/BookingRepositoryImpl.java
+++ b/src/main/java/com/goggles/mentoring_service/infrastructure/persistence/BookingRepositoryImpl.java
@@ -1,0 +1,25 @@
+package com.goggles.mentoring_service.infrastructure.persistence;
+
+import com.goggles.mentoring_service.domain.booking.MentoringBooking;
+import com.goggles.mentoring_service.domain.booking.MentoringBookingId;
+import com.goggles.mentoring_service.domain.booking.repository.MentoringBookingRepository;
+import com.goggles.mentoring_service.infrastructure.persistence.jpa.BookingJpaRepository;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class BookingRepositoryImpl implements MentoringBookingRepository {
+  private final BookingJpaRepository jpaRepository;
+
+  @Override
+  public MentoringBooking save(MentoringBooking mentoringBooking) {
+    return jpaRepository.save(mentoringBooking);
+  }
+
+  @Override
+  public Optional<MentoringBooking> findById(MentoringBookingId id) {
+    return jpaRepository.findById(id);
+  }
+}

--- a/src/main/java/com/goggles/mentoring_service/infrastructure/persistence/jpa/BookingJpaRepository.java
+++ b/src/main/java/com/goggles/mentoring_service/infrastructure/persistence/jpa/BookingJpaRepository.java
@@ -1,0 +1,7 @@
+package com.goggles.mentoring_service.infrastructure.persistence.jpa;
+
+import com.goggles.mentoring_service.domain.booking.MentoringBooking;
+import com.goggles.mentoring_service.domain.booking.MentoringBookingId;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface BookingJpaRepository extends JpaRepository<MentoringBooking, MentoringBookingId> {}

--- a/src/main/java/com/goggles/mentoring_service/presentation/BookingController.java
+++ b/src/main/java/com/goggles/mentoring_service/presentation/BookingController.java
@@ -1,0 +1,28 @@
+package com.goggles.mentoring_service.presentation;
+
+import com.goggles.mentoring_service.application.command.BookingCommand;
+import com.goggles.mentoring_service.application.result.BookingResult;
+import com.goggles.mentoring_service.application.service.BookingService;
+import com.goggles.mentoring_service.presentation.dto.BookingRequest;
+import com.goggles.mentoring_service.presentation.dto.BookingResponse;
+import com.goggles.mentoring_service.presentation.support.UserContext;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/v1/mentoring-bookings")
+@RequiredArgsConstructor
+public class BookingController {
+  private final BookingService bookingService;
+
+  @ResponseStatus(HttpStatus.CREATED)
+  @PostMapping()
+  public BookingResponse.Create createBooking(
+      UserContext userContext, @Valid @RequestBody BookingRequest.Create request) {
+    BookingCommand.Create command = request.toCommand(userContext);
+    BookingResult.Create result = bookingService.createBooking(command);
+    return BookingResponse.Create.of(result);
+  }
+}

--- a/src/main/java/com/goggles/mentoring_service/presentation/InternalMentoringController.java
+++ b/src/main/java/com/goggles/mentoring_service/presentation/InternalMentoringController.java
@@ -1,0 +1,28 @@
+package com.goggles.mentoring_service.presentation;
+
+import com.goggles.mentoring_service.application.command.BookingCommand;
+import com.goggles.mentoring_service.application.result.BookingResult;
+import com.goggles.mentoring_service.application.service.BookingService;
+import com.goggles.mentoring_service.presentation.dto.BookingRequest;
+import com.goggles.mentoring_service.presentation.dto.BookingResponse;
+import com.goggles.mentoring_service.presentation.support.UserContext;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/internal/v1/")
+@RequiredArgsConstructor
+public class InternalMentoringController {
+	private final BookingService bookingService;
+
+	@ResponseStatus(HttpStatus.CREATED)
+	@PostMapping("mentoring-booking")
+	public BookingResponse.Create processMentoringBooking(
+			UserContext userContext, @Valid @RequestBody BookingRequest.Create request) {
+		BookingCommand.Create command = request.toCommand(userContext);
+		BookingResult.Create result = bookingService.createBooking(command);
+		return BookingResponse.Create.of(result);
+	}
+}

--- a/src/main/java/com/goggles/mentoring_service/presentation/InternalMentoringController.java
+++ b/src/main/java/com/goggles/mentoring_service/presentation/InternalMentoringController.java
@@ -25,4 +25,10 @@ public class InternalMentoringController {
 		BookingResult.Create result = bookingService.createBooking(command);
 		return BookingResponse.Create.of(result);
 	}
+
+	@PatchMapping("mentoring-booking/payment-failed")
+	public void processMentoringBookingPaymentFailed(@Valid @RequestBody BookingRequest.PaymentFailed request) {
+		BookingCommand.PaymentFailed command = request.toCommand();
+		bookingService.paymentFailed(command);
+	}
 }

--- a/src/main/java/com/goggles/mentoring_service/presentation/dto/BookingRequest.java
+++ b/src/main/java/com/goggles/mentoring_service/presentation/dto/BookingRequest.java
@@ -32,4 +32,13 @@ public class BookingRequest {
 
   public record BookingTimeSlot(
       @NotNull LocalDate date, @NotNull LocalTime startTime, @NotNull LocalTime endTime) {}
+
+  public record PaymentFailed(
+        @NotNull UUID mentoringBookingId, @NotNull UUID orderId, @NotNull String failureReason
+  ) {
+    public BookingCommand.PaymentFailed toCommand() {
+      MentoringBookingId mentoringBookingId = new MentoringBookingId(mentoringBookingId());
+        return new BookingCommand.PaymentFailed(mentoringBookingId, orderId(), failureReason());
+    }
+  }
 }

--- a/src/main/java/com/goggles/mentoring_service/presentation/dto/BookingRequest.java
+++ b/src/main/java/com/goggles/mentoring_service/presentation/dto/BookingRequest.java
@@ -1,0 +1,35 @@
+package com.goggles.mentoring_service.presentation.dto;
+
+import com.goggles.mentoring_service.application.command.BookingCommand;
+import com.goggles.mentoring_service.application.command.MenteeInfo;
+import com.goggles.mentoring_service.domain.booking.MentoringBookingId;
+import com.goggles.mentoring_service.domain.booking.SessionSlot;
+import com.goggles.mentoring_service.presentation.support.UserContext;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.util.List;
+import java.util.UUID;
+
+public class BookingRequest {
+  public record Create(
+      @NotNull UUID mentoringId,
+      @NotEmpty List<@Valid BookingTimeSlot> bookingTimeSlots,
+      String requestMessage, UUID orderId) {
+    public BookingCommand.Create toCommand(UserContext userContext) {
+      MenteeInfo menteeInfo =
+          new MenteeInfo(userContext.userId(), userContext.userType(), userContext.userName());
+      List<SessionSlot> sessionSlots =
+          bookingTimeSlots().stream()
+              .map(slot -> new SessionSlot(slot.date(), slot.startTime(), slot.endTime()))
+              .toList();
+      return new BookingCommand.Create(menteeInfo, mentoringId(), sessionSlots, requestMessage(),
+              orderId());
+    }
+  }
+
+  public record BookingTimeSlot(
+      @NotNull LocalDate date, @NotNull LocalTime startTime, @NotNull LocalTime endTime) {}
+}

--- a/src/main/java/com/goggles/mentoring_service/presentation/dto/BookingResponse.java
+++ b/src/main/java/com/goggles/mentoring_service/presentation/dto/BookingResponse.java
@@ -1,0 +1,12 @@
+package com.goggles.mentoring_service.presentation.dto;
+
+import com.goggles.mentoring_service.application.result.BookingResult;
+import java.util.UUID;
+
+public class BookingResponse {
+  public record Create(UUID bookingId) {
+    public static Create of(BookingResult.Create createResult) {
+      return new Create(createResult.bookingId());
+    }
+  }
+}

--- a/src/main/java/com/goggles/mentoring_service/presentation/dto/BookingResponse.java
+++ b/src/main/java/com/goggles/mentoring_service/presentation/dto/BookingResponse.java
@@ -4,9 +4,17 @@ import com.goggles.mentoring_service.application.result.BookingResult;
 import java.util.UUID;
 
 public class BookingResponse {
-  public record Create(UUID bookingId) {
+  public record Create(UUID enrollmentId, UUID productId, String productName, long productPrice,
+                       UUID instructorId, String instructorName) {
     public static Create of(BookingResult.Create createResult) {
-      return new Create(createResult.bookingId());
+      return new Create(
+          createResult.enrollmentId(),
+          createResult.productId(),
+          createResult.productName(),
+          createResult.productPrice(),
+          createResult.instructorId(),
+          createResult.instructorName()
+      );
     }
   }
 }

--- a/src/main/java/com/goggles/mentoring_service/presentation/dto/MentoringRequest.java
+++ b/src/main/java/com/goggles/mentoring_service/presentation/dto/MentoringRequest.java
@@ -1,10 +1,13 @@
 package com.goggles.mentoring_service.presentation.dto;
 
 import com.goggles.mentoring_service.application.command.MentoringCommand;
-import com.goggles.mentoring_service.application.command.SessionSlot;
 import com.goggles.mentoring_service.application.command.TimeSchedules;
 import com.goggles.mentoring_service.domain.mentoring.*;
 import com.goggles.mentoring_service.domain.mentoring.exception.InvalidConditionException;
+import com.goggles.mentoring_service.domain.booking.SessionSlot;
+import com.goggles.mentoring_service.domain.mentoring.Format;
+import com.goggles.mentoring_service.domain.mentoring.MentoringDuration;
+import com.goggles.mentoring_service.domain.mentoring.MentoringType;
 import com.goggles.mentoring_service.presentation.support.UserContext;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.*;

--- a/src/main/java/com/goggles/mentoring_service/presentation/dto/MentoringResponse.java
+++ b/src/main/java/com/goggles/mentoring_service/presentation/dto/MentoringResponse.java
@@ -16,7 +16,7 @@ public class MentoringResponse {
 	public record Detail(UUID mentoringId, String title, String subtitle, String description,
 						 MentorInfo mentor, CategoryInfo category, MentoringStatus status,
 						 Format format, MentoringType mentoringType, MentoringDuration duration,
-						 int sessionCount, int maxParticipants, boolean excludeHolidays, int price,
+						 int sessionCount, int maxParticipants, boolean excludeHolidays, long price,
 						 LocalDate endDate) {
 		public static Detail of(MentoringResult.Detail detail) {
 			return new Detail(detail.mentoringId(), detail.title(), detail.subtitle(),
@@ -77,7 +77,7 @@ public class MentoringResponse {
 
 	public record Summary(UUID mentoringId, String title, String subtitle, String mentorName,
 						  String categoryName, MentoringType mentoringType, Format format,
-						  int price, MentoringStatus status) {
+						  long price, MentoringStatus status) {
 
 		public static Summary of(MentoringResult.Summary summary) {
 			return new Summary(summary.mentoringId(), summary.title(), summary.subtitle(),

--- a/src/test/java/com/goggles/mentoring_service/application/service/BookingServiceIntegrationTest.java
+++ b/src/test/java/com/goggles/mentoring_service/application/service/BookingServiceIntegrationTest.java
@@ -64,7 +64,7 @@ class BookingServiceIntegrationTest {
     em.clear();
 
     MentoringBooking booking =
-        bookingRepository.findById(new MentoringBookingId(result.bookingId())).orElseThrow();
+        bookingRepository.findById(new MentoringBookingId(result.enrollmentId())).orElseThrow();
 
     log.info("==== 생성된 예약 ====");
     log.info("bookingId  : {}", booking.getMentoringBookingId().bookingId());

--- a/src/test/java/com/goggles/mentoring_service/application/service/BookingServiceIntegrationTest.java
+++ b/src/test/java/com/goggles/mentoring_service/application/service/BookingServiceIntegrationTest.java
@@ -1,0 +1,138 @@
+package com.goggles.mentoring_service.application.service;
+
+import static com.goggles.mentoring_service.domain.booking.BookingFixture.*;
+import static com.goggles.mentoring_service.domain.mentoring.MentoringFixture.*;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.goggles.mentoring_service.application.command.BookingCommand;
+import com.goggles.mentoring_service.application.command.MenteeInfo;
+import com.goggles.mentoring_service.application.result.BookingResult;
+import com.goggles.mentoring_service.config.TestAuditConfig;
+import com.goggles.mentoring_service.domain._common.UserType;
+import com.goggles.mentoring_service.domain.booking.BookingStatus;
+import com.goggles.mentoring_service.domain.booking.MentoringBooking;
+import com.goggles.mentoring_service.domain.booking.MentoringBookingId;
+import com.goggles.mentoring_service.domain.booking.SessionSlot;
+import com.goggles.mentoring_service.domain.booking.repository.MentoringBookingRepository;
+import com.goggles.mentoring_service.domain.category.MentoringCategory;
+import com.goggles.mentoring_service.domain.category.repository.MentoringCategoryRepository;
+import com.goggles.mentoring_service.domain.mentoring.Format;
+import com.goggles.mentoring_service.domain.mentoring.Mentoring;
+import com.goggles.mentoring_service.domain.mentoring.MentoringId;
+import com.goggles.mentoring_service.domain.mentoring.MentoringType;
+import com.goggles.mentoring_service.domain.mentoring.SessionStatus;
+import com.goggles.mentoring_service.domain.mentoring.exception.MentoringNotFoundException;
+import com.goggles.mentoring_service.domain.mentoring.repository.MentoringRepository;
+import jakarta.persistence.EntityManager;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
+
+@SpringBootTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.ANY)
+@Import(TestAuditConfig.class)
+@ActiveProfiles("test")
+@Transactional
+class BookingServiceIntegrationTest {
+
+  private static final Logger log = LoggerFactory.getLogger(BookingServiceIntegrationTest.class);
+
+  @Autowired private BookingService bookingService;
+  @Autowired private MentoringRepository mentoringRepository;
+  @Autowired private MentoringBookingRepository bookingRepository;
+  @Autowired private MentoringCategoryRepository categoryRepository;
+  @Autowired private EntityManager em;
+
+  @Test
+  void createBooking_persists_to_db() {
+    UUID mentoringId = saveMentoringWithSession(SESSION_DATE_1);
+    BookingCommand.Create command = bookingCommand(mentoringId, sessionSlot(SESSION_DATE_1));
+
+    BookingResult.Create result = bookingService.createBooking(command);
+
+    em.flush();
+    em.clear();
+
+    MentoringBooking booking =
+        bookingRepository.findById(new MentoringBookingId(result.bookingId())).orElseThrow();
+
+    log.info("==== 생성된 예약 ====");
+    log.info("bookingId  : {}", booking.getMentoringBookingId().bookingId());
+    log.info("status     : {}", booking.getStatus());
+    log.info("mentoringId: {}", booking.getBookedMentoring().getMentoringId());
+    log.info("menteeId   : {}", booking.getMentee().getId());
+
+    assertThat(booking.getStatus()).isEqualTo(BookingStatus.PENDING);
+    assertThat(booking.getBookedMentoring().getMentoringId()).isEqualTo(mentoringId);
+    assertThat(booking.getMentee().getId()).isEqualTo(MENTEE_ID);
+  }
+
+  @Test
+  void createBooking_marks_session_as_booked() {
+    UUID mentoringId = saveMentoringWithSession(SESSION_DATE_1);
+    BookingCommand.Create command = bookingCommand(mentoringId, sessionSlot(SESSION_DATE_1));
+
+    bookingService.createBooking(command);
+
+    em.flush();
+    em.clear();
+
+    Mentoring mentoring = mentoringRepository.findById(new MentoringId(mentoringId)).orElseThrow();
+    SessionStatus sessionStatus =
+        mentoring.getSessions().stream()
+            .filter(s -> s.getSessionDate().equals(SESSION_DATE_1))
+            .findFirst()
+            .orElseThrow()
+            .getStatus();
+
+    log.info("==== 세션 상태 확인 ====");
+    log.info("세션 날짜: {} | 상태: {}", SESSION_DATE_1, sessionStatus);
+
+    assertThat(sessionStatus).isEqualTo(SessionStatus.BOOKED);
+  }
+
+  @Test
+  void createBooking_mentoring_not_found() {
+    UUID unknownId = UUID.randomUUID();
+    BookingCommand.Create command = bookingCommand(unknownId, sessionSlot());
+
+    assertThatThrownBy(() -> bookingService.createBooking(command))
+        .isInstanceOf(MentoringNotFoundException.class);
+  }
+
+  // ── 헬퍼 ─────────────────────────────────────────────────────────────────
+
+  private UUID saveMentoringWithSession(LocalDate sessionDate) {
+    MentoringCategory category =
+        MentoringCategory.create(MENTOR_ID, UserType.MASTER, CATEGORY_NAME, CATEGORY_CODE);
+    categoryRepository.save(category);
+
+    Mentoring mentoring =
+        defaultMentoringBuilder()
+            .categoryId(category.getMentoringCategoryId().categoryId())
+            .categoryName(category.getName())
+            .categoryCode(category.getCode())
+            .format(Format.SINGLE)
+            .mentoringType(MentoringType.ONE_ON_ONE)
+            .sessions(List.of(session(sessionDate)))
+            .build();
+    mentoringRepository.save(mentoring);
+
+    return mentoring.getMentoringId().mentoringId();
+  }
+
+  private BookingCommand.Create bookingCommand(UUID mentoringId, SessionSlot slot) {
+    MenteeInfo menteeInfo = new MenteeInfo(MENTEE_ID, UserType.STUDENT, MENTEE_NAME);
+    return new BookingCommand.Create(menteeInfo, mentoringId, List.of(slot), REQUEST_MESSAGE, UUID.randomUUID());
+  }
+}

--- a/src/test/java/com/goggles/mentoring_service/application/service/BookingServiceTest.java
+++ b/src/test/java/com/goggles/mentoring_service/application/service/BookingServiceTest.java
@@ -1,0 +1,96 @@
+package com.goggles.mentoring_service.application.service;
+
+import static com.goggles.mentoring_service.domain.booking.BookingFixture.*;
+import static com.goggles.mentoring_service.domain.mentoring.MentoringFixture.*;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+
+import com.goggles.mentoring_service.application.command.BookingCommand;
+import com.goggles.mentoring_service.application.command.MenteeInfo;
+import com.goggles.mentoring_service.application.result.BookingResult;
+import com.goggles.mentoring_service.domain._common.UserType;
+import com.goggles.mentoring_service.domain.booking.repository.MentoringBookingRepository;
+import com.goggles.mentoring_service.domain.mentoring.Mentoring;
+import com.goggles.mentoring_service.domain.mentoring.exception.MentoringNotFoundException;
+import com.goggles.mentoring_service.domain.mentoring.repository.MentoringRepository;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+@ExtendWith(MockitoExtension.class)
+class BookingServiceTest {
+
+  private static final Logger log = LoggerFactory.getLogger(BookingServiceTest.class);
+
+  @InjectMocks private BookingService bookingService;
+
+  @Mock private MentoringBookingRepository bookingRepository;
+
+  @Mock private MentoringRepository mentoringRepository;
+
+  @Test
+  void createBooking_success() {
+    Mentoring mentoring =
+        defaultMentoringBuilder().sessions(List.of(session(SESSION_DATE_1))).build();
+    given(mentoringRepository.findById(any())).willReturn(Optional.of(mentoring));
+
+    BookingResult.Create result = bookingService.createBooking(defaultCommand(mentoring));
+
+    log.info("==== 예약 생성 결과 ====");
+    log.info("bookingId: {}", result.bookingId());
+
+    assertThat(result.bookingId()).isNotNull();
+    verify(bookingRepository).save(any());
+  }
+
+  @Test
+  void createBooking_mentoring_not_found() {
+    given(mentoringRepository.findById(any())).willReturn(Optional.empty());
+    UUID unknownId = UUID.randomUUID();
+    BookingCommand.Create command =
+        new BookingCommand.Create(
+            new MenteeInfo(MENTEE_ID, UserType.STUDENT, MENTEE_NAME),
+            unknownId,
+            List.of(sessionSlot()),
+            REQUEST_MESSAGE, null);
+
+    log.info("존재하지 않는 멘토링 예약 시도: {}", unknownId);
+    assertThatThrownBy(() -> bookingService.createBooking(command))
+        .isInstanceOf(MentoringNotFoundException.class);
+  }
+
+  @Test
+  void createBooking_fails_if_instructor_books() {
+    Mentoring mentoring =
+        defaultMentoringBuilder().sessions(List.of(session(SESSION_DATE_1))).build();
+    given(mentoringRepository.findById(any())).willReturn(Optional.of(mentoring));
+
+    BookingCommand.Create command =
+        new BookingCommand.Create(
+            new MenteeInfo(UUID.randomUUID(), UserType.INSTRUCTOR, "이강사"),
+            mentoring.getMentoringId().mentoringId(),
+            List.of(sessionSlot()),
+            REQUEST_MESSAGE,null);
+
+    assertThatThrownBy(() -> bookingService.createBooking(command))
+        .isInstanceOf(RuntimeException.class);
+  }
+
+  private BookingCommand.Create defaultCommand(Mentoring mentoring) {
+    return new BookingCommand.Create(
+        new MenteeInfo(MENTEE_ID, UserType.STUDENT, MENTEE_NAME),
+        mentoring.getMentoringId().mentoringId(),
+        List.of(sessionSlot(SESSION_DATE_1)),
+        REQUEST_MESSAGE,null);
+  }
+}

--- a/src/test/java/com/goggles/mentoring_service/application/service/BookingServiceTest.java
+++ b/src/test/java/com/goggles/mentoring_service/application/service/BookingServiceTest.java
@@ -47,9 +47,9 @@ class BookingServiceTest {
     BookingResult.Create result = bookingService.createBooking(defaultCommand(mentoring));
 
     log.info("==== 예약 생성 결과 ====");
-    log.info("bookingId: {}", result.bookingId());
+    log.info("bookingId: {}", result.enrollmentId());
 
-    assertThat(result.bookingId()).isNotNull();
+    assertThat(result.enrollmentId()).isNotNull();
     verify(bookingRepository).save(any());
   }
 

--- a/src/test/java/com/goggles/mentoring_service/application/service/CategoryServiceTest.java
+++ b/src/test/java/com/goggles/mentoring_service/application/service/CategoryServiceTest.java
@@ -32,11 +32,11 @@ class CategoryServiceTest {
 
 	// ── getActiveCategories ───────────────────────────────────────────────────
 
-	@Test
-	void getActiveCategories_returns_mapped_results() {
-		MentoringCategory c1 = createActive(0);
-		MentoringCategory c2 = createActive(1);
-		given(categoryRepository.findByActiveIsTrue()).willReturn(List.of(c1, c2));
+  @Test
+  void getActiveCategories_success() {
+    MentoringCategory c1 = createActive(0);
+    MentoringCategory c2 = createActive(1);
+    given(categoryRepository.findByActiveIsTrue()).willReturn(List.of(c1, c2));
 
 		List<CategoryResult.Info> result = categoryService.getActiveCategories();
 
@@ -53,9 +53,9 @@ class CategoryServiceTest {
 				.getName()).isEqualTo(c2.getName());
 	}
 
-	@Test
-	void getActiveCategories_returns_empty_when_no_active_categories() {
-		given(categoryRepository.findByActiveIsTrue()).willReturn(List.of());
+  @Test
+  void getActiveCategories_empty() {
+    given(categoryRepository.findByActiveIsTrue()).willReturn(List.of());
 
 		List<CategoryResult.Info> result = categoryService.getActiveCategories();
 
@@ -64,12 +64,11 @@ class CategoryServiceTest {
 
 	// ── getAllCategories ──────────────────────────────────────────────────────
 
-	@Test
-	void getAllCategories_success_when_master() {
-		MentoringCategory active = createActive(0);
-		MentoringCategory inactive = createInactive();
-		given(categoryRepository.findAllByOrderBySortOrderAsc()).willReturn(
-				List.of(active, inactive));
+  @Test
+  void getAllCategories_success() {
+    MentoringCategory active = createActive(0);
+    MentoringCategory inactive = createInactive();
+    given(categoryRepository.findAllByOrderBySortOrderAsc()).willReturn(List.of(active, inactive));
 
 		List<CategoryResult.Info> result = categoryService.getAllCategories(
 				new CategoryCommand.GetList(UUID.randomUUID(), UserType.MASTER));
@@ -85,10 +84,12 @@ class CategoryServiceTest {
 				.getSortOrder()).isNull();
 	}
 
-	@Test
-	void getAllCategories_throws_forbidden_when_not_master() {
-		assertThatThrownBy(() -> categoryService.getAllCategories(
-				new CategoryCommand.GetList(UUID.randomUUID(), UserType.INSTRUCTOR))).isInstanceOf(
-				ForbiddenException.class);
-	}
+  @Test
+  void getAllCategories_forbidden_if_not_master() {
+    assertThatThrownBy(
+            () ->
+                categoryService.getAllCategories(
+                    new CategoryCommand.GetList(UUID.randomUUID(), UserType.INSTRUCTOR)))
+        .isInstanceOf(ForbiddenException.class);
+  }
 }

--- a/src/test/java/com/goggles/mentoring_service/application/service/MentoringServiceIntegrationTest.java
+++ b/src/test/java/com/goggles/mentoring_service/application/service/MentoringServiceIntegrationTest.java
@@ -1,5 +1,8 @@
 package com.goggles.mentoring_service.application.service;
 
+import static com.goggles.mentoring_service.domain.mentoring.MentoringFixture.*;
+import static org.assertj.core.api.Assertions.assertThat;
+
 import com.goggles.common.pagination.CommonPageRequest;
 import com.goggles.mentoring_service.application.command.MentoringCommand;
 import com.goggles.mentoring_service.application.result.MentoringResult;
@@ -10,6 +13,9 @@ import com.goggles.mentoring_service.domain.category.repository.MentoringCategor
 import com.goggles.mentoring_service.domain.mentoring.*;
 import com.goggles.mentoring_service.domain.mentoring.repository.MentoringRepository;
 import jakarta.persistence.EntityManager;
+import java.time.DayOfWeek;
+import java.util.List;
+import java.util.UUID;
 import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -21,13 +27,6 @@ import org.springframework.data.domain.Page;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.time.DayOfWeek;
-import java.util.List;
-import java.util.UUID;
-
-import static com.goggles.mentoring_service.domain.mentoring.MentoringFixture.*;
-import static org.assertj.core.api.Assertions.assertThat;
-
 @SpringBootTest
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.ANY)
 @Import(TestAuditConfig.class)
@@ -35,314 +34,361 @@ import static org.assertj.core.api.Assertions.assertThat;
 @Transactional
 class MentoringServiceIntegrationTest {
 
-	private static final Logger log =
-			LoggerFactory.getLogger(MentoringServiceIntegrationTest.class);
+  private static final Logger log = LoggerFactory.getLogger(MentoringServiceIntegrationTest.class);
 
-	@Autowired
-	private MentoringService mentoringService;
+  @Autowired private MentoringService mentoringService;
 
-	@Autowired
-	private MentoringRepository mentoringRepository;
+  @Autowired private MentoringRepository mentoringRepository;
 
-	@Autowired
-	private MentoringCategoryRepository categoryRepository;
+  @Autowired private MentoringCategoryRepository categoryRepository;
 
-	@Autowired
-	private EntityManager em;
+  @Autowired private EntityManager em;
 
-	// ── 생성 ─────────────────────────────────────────────────────────────────
+  // ── 생성 ─────────────────────────────────────────────────────────────────
 
-	@Test
-	void createMentoring_persists_to_db() {
-		MentoringCategory category =
-				MentoringCategory.create(MENTOR_ID, UserType.MASTER, CATEGORY_NAME, CATEGORY_CODE);
-		categoryRepository.save(category);
+  @Test
+  void createMentoring_persists_to_db() {
+    MentoringCategory category =
+        MentoringCategory.create(MENTOR_ID, UserType.MASTER, CATEGORY_NAME, CATEGORY_CODE);
+    categoryRepository.save(category);
 
-		MentoringCommand.Create command =
-				new MentoringCommand.Create(MENTOR_ID, MENTOR_NAME, MENTOR_FIELD, MENTOR_EMAIL,
-						MENTOR_TYPE, category.getMentoringCategoryId()
-						.categoryId(), TITLE, SUBTITLE, DESCRIPTION, DURATION,
-						MentoringType.ONE_ON_ONE, Format.SINGLE, SESSION_COUNT, MAX_PARTICIPANTS,
-						false, PRICE, null,
-						List.of(sessionSlot(SESSION_DATE_1), sessionSlot(SESSION_DATE_2)),
-						List.of(timeSchedules(DayOfWeek.MONDAY),
-								timeSchedules(DayOfWeek.WEDNESDAY)));
+    MentoringCommand.Create command =
+        new MentoringCommand.Create(
+            MENTOR_ID,
+            MENTOR_NAME,
+            MENTOR_FIELD,
+            MENTOR_EMAIL,
+            MENTOR_TYPE,
+            category.getMentoringCategoryId().categoryId(),
+            TITLE,
+            SUBTITLE,
+            DESCRIPTION,
+            DURATION,
+            MentoringType.ONE_ON_ONE,
+            Format.SINGLE,
+            SESSION_COUNT,
+            MAX_PARTICIPANTS,
+            false,
+            PRICE,
+            null,
+            List.of(sessionSlot(SESSION_DATE_1), sessionSlot(SESSION_DATE_2)),
+            List.of(timeSchedules(DayOfWeek.MONDAY), timeSchedules(DayOfWeek.WEDNESDAY)));
 
-		UUID mentoringId = mentoringService.createMentoring(command);
+    UUID mentoringId = mentoringService.createMentoring(command);
 
-		em.flush();
-		em.clear();
+    em.flush();
+    em.clear();
 
-		Mentoring found = mentoringRepository.findById(new MentoringId(mentoringId))
-				.orElseThrow();
+    Mentoring found = mentoringRepository.findById(new MentoringId(mentoringId)).orElseThrow();
 
-		log.info("==== 생성된 멘토링 ====");
-		log.info("id       : {}", found.getMentoringId()
-				.mentoringId());
-		log.info("title    : {}", found.getTitle());
-		log.info("status   : {}", found.getStatus());
-		log.info("price    : {}", found.getPrice());
-		log.info("duration : {}", found.getDuration());
-		log.info("mentor   : {} / {} / {}", found.getMentor()
-				.getName(), found.getMentor()
-				.getField(), found.getMentor()
-				.getEmail());
-		log.info("category : {} ({})", found.getMentoringCategory()
-				.getName(), found.getMentoringCategory()
-				.getCode());
+    log.info("==== 생성된 멘토링 ====");
+    log.info("id       : {}", found.getMentoringId().mentoringId());
+    log.info("title    : {}", found.getTitle());
+    log.info("status   : {}", found.getStatus());
+    log.info("price    : {}", found.getPrice());
+    log.info("duration : {}", found.getDuration());
+    log.info(
+        "mentor   : {} / {} / {}",
+        found.getMentor().getName(),
+        found.getMentor().getField(),
+        found.getMentor().getEmail());
+    log.info(
+        "category : {} ({})",
+        found.getMentoringCategory().getName(),
+        found.getMentoringCategory().getCode());
 
-		log.info("==== 반복 패턴 ({}) ====", found.getRepeatPatterns()
-				.size());
-		found.getRepeatPatterns()
-				.forEach(p -> log.info("  {} {} ~ {}", p.getDayOfWeek(), p.getStartTime(),
-						p.getEndTime()));
+    log.info("==== 반복 패턴 ({}) ====", found.getRepeatPatterns().size());
+    found
+        .getRepeatPatterns()
+        .forEach(p -> log.info("  {} {} ~ {}", p.getDayOfWeek(), p.getStartTime(), p.getEndTime()));
 
-		log.info("==== 세션 ({}) ====", found.getSessions()
-				.size());
-		found.getSessions()
-				.forEach(s -> log.info("  {} {} ~ {} [{}]", s.getSessionDate(),
-						s.getSessionStartTime(), s.getSessionEndTime(), s.getStatus()));
+    log.info("==== 세션 ({}) ====", found.getSessions().size());
+    found
+        .getSessions()
+        .forEach(
+            s ->
+                log.info(
+                    "  {} {} ~ {} [{}]",
+                    s.getSessionDate(),
+                    s.getSessionStartTime(),
+                    s.getSessionEndTime(),
+                    s.getStatus()));
 
-		assertThat(found.getTitle()).isEqualTo(TITLE);
-		assertThat(found.getStatus()).isEqualTo(MentoringStatus.INACTIVE);
-		assertThat(found.getRepeatPatterns()).hasSize(2);
-		assertThat(found.getSessions()).hasSize(2);
-	}
+    assertThat(found.getTitle()).isEqualTo(TITLE);
+    assertThat(found.getStatus()).isEqualTo(MentoringStatus.INACTIVE);
+    assertThat(found.getRepeatPatterns()).hasSize(2);
+    assertThat(found.getSessions()).hasSize(2);
+  }
 
-	// ── 상세 조회 ─────────────────────────────────────────────────────────────
+  // ── 상세 조회 ─────────────────────────────────────────────────────────────
 
-	@Test
-	void getMentoring_returns_full_detail() {
-		UUID mentoringId = saveMentoring(TITLE, PRICE);
-		em.flush();
-		em.clear();
+  @Test
+  void getMentoring_success() {
+    UUID mentoringId = saveMentoring(TITLE, PRICE);
+    em.flush();
+    em.clear();
 
-		MentoringResult.Detail detail = mentoringService.getMentoring(mentoringId);
+    MentoringResult.Detail detail = mentoringService.getMentoring(mentoringId);
 
-		log.info("==== 멘토링 상세 조회 ====");
-		log.info("id       : {}", detail.mentoringId());
-		log.info("title    : {}", detail.title());
-		log.info("subtitle : {}", detail.subtitle());
-		log.info("status   : {} | format: {} | type: {}", detail.status(), detail.format(),
-				detail.mentoringType());
-		log.info("price    : {}원 | duration: {}", detail.price(), detail.duration());
-		log.info("mentor   : {} ({})", detail.mentor()
-				.name(), detail.mentor()
-				.field());
-		log.info("category : {} [{}]", detail.category()
-				.name(), detail.category()
-				.code());
+    log.info("==== 멘토링 상세 조회 ====");
+    log.info("id       : {}", detail.mentoringId());
+    log.info("title    : {}", detail.title());
+    log.info("subtitle : {}", detail.subtitle());
+    log.info(
+        "status   : {} | format: {} | type: {}",
+        detail.status(),
+        detail.format(),
+        detail.mentoringType());
+    log.info("price    : {}원 | duration: {}", detail.price(), detail.duration());
+    log.info("mentor   : {} ({})", detail.mentor().name(), detail.mentor().field());
+    log.info("category : {} [{}]", detail.category().name(), detail.category().code());
 
-		assertThat(detail.mentoringId()).isEqualTo(mentoringId);
-		assertThat(detail.title()).isEqualTo(TITLE);
-		assertThat(detail.subtitle()).isEqualTo(SUBTITLE);
-		assertThat(detail.description()).isEqualTo(DESCRIPTION);
-		assertThat(detail.status()).isEqualTo(MentoringStatus.INACTIVE);
-		assertThat(detail.format()).isEqualTo(Format.SINGLE);
-		assertThat(detail.mentoringType()).isEqualTo(MentoringType.ONE_ON_ONE);
-		assertThat(detail.price()).isEqualTo(PRICE);
-		assertThat(detail.duration()).isEqualTo(DURATION);
-		assertThat(detail.mentor()
-				.name()).isEqualTo(MENTOR_NAME);
-		assertThat(detail.mentor()
-				.field()).isEqualTo(MENTOR_FIELD);
-		assertThat(detail.category()
-				.name()).isEqualTo(CATEGORY_NAME);
-		assertThat(detail.category()
-				.code()).isEqualTo(CATEGORY_CODE);
-	}
+    assertThat(detail.mentoringId()).isEqualTo(mentoringId);
+    assertThat(detail.title()).isEqualTo(TITLE);
+    assertThat(detail.subtitle()).isEqualTo(SUBTITLE);
+    assertThat(detail.description()).isEqualTo(DESCRIPTION);
+    assertThat(detail.status()).isEqualTo(MentoringStatus.INACTIVE);
+    assertThat(detail.format()).isEqualTo(Format.SINGLE);
+    assertThat(detail.mentoringType()).isEqualTo(MentoringType.ONE_ON_ONE);
+    assertThat(detail.price()).isEqualTo(PRICE);
+    assertThat(detail.duration()).isEqualTo(DURATION);
+    assertThat(detail.mentor().name()).isEqualTo(MENTOR_NAME);
+    assertThat(detail.mentor().field()).isEqualTo(MENTOR_FIELD);
+    assertThat(detail.category().name()).isEqualTo(CATEGORY_NAME);
+    assertThat(detail.category().code()).isEqualTo(CATEGORY_CODE);
+  }
 
-	// ── 스케쥴 조회 ───────────────────────────────────────────────────────────
+  // ── 스케쥴 조회 ───────────────────────────────────────────────────────────
 
-	@Test
-	void getMentoringSchedules_returns_patterns_and_sessions() {
-		MentoringCategory category = createAndSaveCategory();
-		MentoringCommand.Create command =
-				new MentoringCommand.Create(MENTOR_ID, MENTOR_NAME, MENTOR_FIELD, MENTOR_EMAIL,
-						MENTOR_TYPE, category.getMentoringCategoryId()
-						.categoryId(), TITLE, SUBTITLE, DESCRIPTION, DURATION,
-						MentoringType.ONE_ON_ONE, Format.SINGLE, SESSION_COUNT, MAX_PARTICIPANTS,
-						false, PRICE, null,
-						List.of(sessionSlot(SESSION_DATE_1), sessionSlot(SESSION_DATE_2)),
-						List.of(timeSchedules(DayOfWeek.MONDAY),
-								timeSchedules(DayOfWeek.WEDNESDAY)));
-		UUID mentoringId = mentoringService.createMentoring(command);
-		em.flush();
-		em.clear();
+  @Test
+  void getMentoringSchedules_success() {
+    MentoringCategory category = createAndSaveCategory();
+    MentoringCommand.Create command =
+        new MentoringCommand.Create(
+            MENTOR_ID,
+            MENTOR_NAME,
+            MENTOR_FIELD,
+            MENTOR_EMAIL,
+            MENTOR_TYPE,
+            category.getMentoringCategoryId().categoryId(),
+            TITLE,
+            SUBTITLE,
+            DESCRIPTION,
+            DURATION,
+            MentoringType.ONE_ON_ONE,
+            Format.SINGLE,
+            SESSION_COUNT,
+            MAX_PARTICIPANTS,
+            false,
+            PRICE,
+            null,
+            List.of(sessionSlot(SESSION_DATE_1), sessionSlot(SESSION_DATE_2)),
+            List.of(timeSchedules(DayOfWeek.MONDAY), timeSchedules(DayOfWeek.WEDNESDAY)));
+    UUID mentoringId = mentoringService.createMentoring(command);
+    em.flush();
+    em.clear();
 
-		MentoringResult.Schedules schedules = mentoringService.getMentoringSchedules(mentoringId);
+    MentoringResult.Schedules schedules = mentoringService.getMentoringSchedules(mentoringId);
 
-		log.info("==== 멘토링 스케쥴 조회 ====");
-		log.info("반복 패턴 ({}):", schedules.repeatPatterns()
-				.size());
-		schedules.repeatPatterns()
-				.forEach(p -> log.info("  요일: {} | {} ~ {}", p.dayOfWeek(), p.startTime(),
-						p.endTime()));
-		log.info("세션 ({}):", schedules.sessions()
-				.size());
-		schedules.sessions()
-				.forEach(s -> log.info("  날짜: {} | {} ~ {} | 상태: {}", s.date(), s.startTime(),
-						s.endTime(), s.status()));
+    log.info("==== 멘토링 스케쥴 조회 ====");
+    log.info("반복 패턴 ({}):", schedules.repeatPatterns().size());
+    schedules
+        .repeatPatterns()
+        .forEach(p -> log.info("  요일: {} | {} ~ {}", p.dayOfWeek(), p.startTime(), p.endTime()));
+    log.info("세션 ({}):", schedules.sessions().size());
+    schedules
+        .sessions()
+        .forEach(
+            s ->
+                log.info(
+                    "  날짜: {} | {} ~ {} | 상태: {}",
+                    s.date(),
+                    s.startTime(),
+                    s.endTime(),
+                    s.status()));
 
-		assertThat(schedules.repeatPatterns()).hasSize(2);
-		assertThat(schedules.repeatPatterns()
-				.get(0)
-				.dayOfWeek()).isEqualTo(DayOfWeek.MONDAY);
-		assertThat(schedules.repeatPatterns()
-				.get(0)
-				.startTime()).isEqualTo(START_TIME);
-		assertThat(schedules.repeatPatterns()
-				.get(1)
-				.dayOfWeek()).isEqualTo(DayOfWeek.WEDNESDAY);
-		assertThat(schedules.sessions()).hasSize(2);
-		assertThat(schedules.sessions()
-				.get(0)
-				.date()).isEqualTo(SESSION_DATE_1);
-		assertThat(schedules.sessions()
-				.get(1)
-				.date()).isEqualTo(SESSION_DATE_2);
-	}
+    assertThat(schedules.repeatPatterns()).hasSize(2);
+    assertThat(schedules.repeatPatterns().get(0).dayOfWeek()).isEqualTo(DayOfWeek.MONDAY);
+    assertThat(schedules.repeatPatterns().get(0).startTime()).isEqualTo(START_TIME);
+    assertThat(schedules.repeatPatterns().get(1).dayOfWeek()).isEqualTo(DayOfWeek.WEDNESDAY);
+    assertThat(schedules.sessions()).hasSize(2);
+    assertThat(schedules.sessions().get(0).date()).isEqualTo(SESSION_DATE_1);
+    assertThat(schedules.sessions().get(1).date()).isEqualTo(SESSION_DATE_2);
+  }
 
-	// ── 검색/목록 조회 ────────────────────────────────────────────────────────
+  // ── 검색/목록 조회 ────────────────────────────────────────────────────────
 
-	@Test
-	void searchMentorings_filters_by_keyword_title() {
-		saveMentoring("스프링 부트 멘토링", PRICE);
-		saveMentoring("리액트 입문 과정", 30_000);
-		em.flush();
-		em.clear();
+  @Test
+  void searchMentorings_filters_by_keyword_title() {
+    saveMentoring("스프링 부트 멘토링", PRICE);
+    saveMentoring("리액트 입문 과정", 30_000);
+    em.flush();
+    em.clear();
 
-		MentoringSearchCondition condition =
-				new MentoringSearchCondition("스프링", null, null, null, null, null);
-		Page<MentoringResult.Summary> result =
-				mentoringService.searchMentorings(condition, CommonPageRequest.of(0, 10));
+    MentoringSearchCondition condition =
+        new MentoringSearchCondition("스프링", null, null, null, null, null);
+    Page<MentoringResult.Summary> result =
+        mentoringService.searchMentorings(condition, CommonPageRequest.of(0, 10));
 
-		log.info("==== 키워드 '스프링' 검색 결과 ====");
-		log.info("총 {}건 검색됨", result.getTotalElements());
-		result.getContent()
-				.forEach(s -> log.info("  [{}] {} | {}원 | 멘토: {}", s.status(), s.title(), s.price(),
-						s.mentorName()));
+    log.info("==== 키워드 '스프링' 검색 결과 ====");
+    log.info("총 {}건 검색됨", result.getTotalElements());
+    result
+        .getContent()
+        .forEach(
+            s ->
+                log.info(
+                    "  [{}] {} | {}원 | 멘토: {}", s.status(), s.title(), s.price(), s.mentorName()));
 
-		assertThat(result.getTotalElements()).isEqualTo(1);
-		assertThat(result.getContent()
-				.get(0)
-				.title()).contains("스프링");
-	}
+    assertThat(result.getTotalElements()).isEqualTo(1);
+    assertThat(result.getContent().get(0).title()).contains("스프링");
+  }
 
-	@Test
-	void searchMentorings_filters_by_mentor_id() {
-		UUID otherMentorId = UUID.fromString("00000000-0000-0000-0000-000000000099");
-		saveMentoring(TITLE, PRICE);
-		saveMentoringWithMentor(otherMentorId, "다른 멘토 멘토링");
-		em.flush();
-		em.clear();
+  @Test
+  void searchMentorings_filters_by_mentor_id() {
+    UUID otherMentorId = UUID.fromString("00000000-0000-0000-0000-000000000099");
+    saveMentoring(TITLE, PRICE);
+    saveMentoringWithMentor(otherMentorId, "다른 멘토 멘토링");
+    em.flush();
+    em.clear();
 
-		MentoringSearchCondition condition =
-				new MentoringSearchCondition(null, null, MENTOR_ID, null, null, null);
-		Page<MentoringResult.Summary> result =
-				mentoringService.searchMentorings(condition, CommonPageRequest.of(0, 10));
+    MentoringSearchCondition condition =
+        new MentoringSearchCondition(null, null, MENTOR_ID, null, null, null);
+    Page<MentoringResult.Summary> result =
+        mentoringService.searchMentorings(condition, CommonPageRequest.of(0, 10));
 
-		log.info("==== 멘토 ID {} 필터 결과 ====", MENTOR_ID);
-		log.info("총 {}건 검색됨", result.getTotalElements());
-		result.getContent()
-				.forEach(
-						s -> log.info("  [{}] {} | 멘토: {}", s.status(), s.title(), s.mentorName()));
+    log.info("==== 멘토 ID {} 필터 결과 ====", MENTOR_ID);
+    log.info("총 {}건 검색됨", result.getTotalElements());
+    result
+        .getContent()
+        .forEach(s -> log.info("  [{}] {} | 멘토: {}", s.status(), s.title(), s.mentorName()));
 
-		assertThat(result.getTotalElements()).isEqualTo(1);
-		assertThat(result.getContent()
-				.get(0)
-				.mentorName()).isEqualTo(MENTOR_NAME);
-	}
+    assertThat(result.getTotalElements()).isEqualTo(1);
+    assertThat(result.getContent().get(0).mentorName()).isEqualTo(MENTOR_NAME);
+  }
 
-	@Test
-	void searchMentorings_returns_all_without_condition() {
-		saveMentoring("멘토링 A", 10_000);
-		saveMentoring("멘토링 B", 20_000);
-		saveMentoring("멘토링 C", 30_000);
-		em.flush();
-		em.clear();
+  @Test
+  void searchMentorings_no_filter() {
+    saveMentoring("멘토링 A", 10_000);
+    saveMentoring("멘토링 B", 20_000);
+    saveMentoring("멘토링 C", 30_000);
+    em.flush();
+    em.clear();
 
-		MentoringSearchCondition condition =
-				new MentoringSearchCondition(null, null, null, null, null, null);
-		Page<MentoringResult.Summary> result =
-				mentoringService.searchMentorings(condition, CommonPageRequest.of(0, 10));
+    MentoringSearchCondition condition =
+        new MentoringSearchCondition(null, null, null, null, null, null);
+    Page<MentoringResult.Summary> result =
+        mentoringService.searchMentorings(condition, CommonPageRequest.of(0, 10));
 
-		log.info("==== 전체 멘토링 목록 조회 ====");
-		log.info("총 {}건 (페이지당 {}, 현재 {}페이지)", result.getTotalElements(), result.getSize(),
-				result.getNumber());
-		result.getContent()
-				.forEach(s -> log.info("  [{}] {} | {}원", s.status(), s.title(), s.price()));
+    log.info("==== 전체 멘토링 목록 조회 ====");
+    log.info(
+        "총 {}건 (페이지당 {}, 현재 {}페이지)",
+        result.getTotalElements(),
+        result.getSize(),
+        result.getNumber());
+    result.getContent().forEach(s -> log.info("  [{}] {} | {}원", s.status(), s.title(), s.price()));
 
-		assertThat(result.getTotalElements()).isGreaterThanOrEqualTo(3);
-	}
+    assertThat(result.getTotalElements()).isGreaterThanOrEqualTo(3);
+  }
 
-	@Test
-	void searchMentorings_pagination_returns_correct_metadata() {
-		for (int i = 1; i <= 5; i++) {
-			saveMentoring("멘토링 " + i, i * 10_000);
-		}
-		em.flush();
-		em.clear();
+  @Test
+  void searchMentorings_pagination() {
+    for (int i = 1; i <= 5; i++) {
+      saveMentoring("멘토링 " + i, i * 10_000);
+    }
+    em.flush();
+    em.clear();
 
-		log.info("size=10 (허용된 최솟값): 5건이므로 첫 페이지에 전체가 담김");
-		Page<MentoringResult.Summary> page0 = mentoringService.searchMentorings(
-				new MentoringSearchCondition(null, null, null, null, null, null),
-				CommonPageRequest.of(0, 10));
+    log.info("size=10 (허용된 최솟값): 5건이므로 첫 페이지에 전체가 담김");
+    Page<MentoringResult.Summary> page0 =
+        mentoringService.searchMentorings(
+            new MentoringSearchCondition(null, null, null, null, null, null),
+            CommonPageRequest.of(0, 10));
 
-		log.info("==== 페이지네이션 메타데이터 확인 (size=10) ====");
-		log.info("0페이지: {}건 / 전체 {}건 / 총 {}페이지 / first={} / last={}", page0.getContent()
-						.size(), page0.getTotalElements(), page0.getTotalPages(), page0.isFirst(),
-				page0.isLast());
-		page0.getContent()
-				.forEach(s -> log.info("  {} | {}원", s.title(), s.price()));
+    log.info("==== 페이지네이션 메타데이터 확인 (size=10) ====");
+    log.info(
+        "0페이지: {}건 / 전체 {}건 / 총 {}페이지 / first={} / last={}",
+        page0.getContent().size(),
+        page0.getTotalElements(),
+        page0.getTotalPages(),
+        page0.isFirst(),
+        page0.isLast());
+    page0.getContent().forEach(s -> log.info("  {} | {}원", s.title(), s.price()));
 
-		assertThat(page0.getContent()).hasSizeGreaterThanOrEqualTo(5);
-		assertThat(page0.getTotalElements()).isGreaterThanOrEqualTo(5);
-		assertThat(page0.getSize()).isEqualTo(10);
-		assertThat(page0.getNumber()).isEqualTo(0);
-		assertThat(page0.isFirst()).isTrue();
+    assertThat(page0.getContent()).hasSizeGreaterThanOrEqualTo(5);
+    assertThat(page0.getTotalElements()).isGreaterThanOrEqualTo(5);
+    assertThat(page0.getSize()).isEqualTo(10);
+    assertThat(page0.getNumber()).isEqualTo(0);
+    assertThat(page0.isFirst()).isTrue();
 
-		log.info("2페이지 요청 → 범위 초과, 데이터 없음");
-		Page<MentoringResult.Summary> page2 = mentoringService.searchMentorings(
-				new MentoringSearchCondition(null, null, null, null, null, null),
-				CommonPageRequest.of(2, 10));
+    log.info("2페이지 요청 → 범위 초과, 데이터 없음");
+    Page<MentoringResult.Summary> page2 =
+        mentoringService.searchMentorings(
+            new MentoringSearchCondition(null, null, null, null, null, null),
+            CommonPageRequest.of(2, 10));
 
-		log.info("2페이지: {}건", page2.getContent()
-				.size());
-		assertThat(page2.getContent()).isEmpty();
-		assertThat(page2.getNumber()).isEqualTo(2);
-	}
+    log.info("2페이지: {}건", page2.getContent().size());
+    assertThat(page2.getContent()).isEmpty();
+    assertThat(page2.getNumber()).isEqualTo(2);
+  }
 
-	// ── 헬퍼 ─────────────────────────────────────────────────────────────────
+  // ── 헬퍼 ─────────────────────────────────────────────────────────────────
 
-	private MentoringCategory createAndSaveCategory() {
-		MentoringCategory category =
-				MentoringCategory.create(MENTOR_ID, UserType.MASTER, CATEGORY_NAME, CATEGORY_CODE);
-		categoryRepository.save(category);
-		return category;
-	}
+  private MentoringCategory createAndSaveCategory() {
+    MentoringCategory category =
+        MentoringCategory.create(MENTOR_ID, UserType.MASTER, CATEGORY_NAME, CATEGORY_CODE);
+    categoryRepository.save(category);
+    return category;
+  }
 
-	private UUID saveMentoring(String title, int price) {
-		MentoringCategory category = createAndSaveCategory();
-		MentoringCommand.Create command =
-				new MentoringCommand.Create(MENTOR_ID, MENTOR_NAME, MENTOR_FIELD, MENTOR_EMAIL,
-						MENTOR_TYPE, category.getMentoringCategoryId()
-						.categoryId(), title, SUBTITLE, DESCRIPTION, DURATION,
-						MentoringType.ONE_ON_ONE, Format.SINGLE, SESSION_COUNT, MAX_PARTICIPANTS,
-						false, price, null, List.of(sessionSlot(SESSION_DATE_1)),
-						List.of(timeSchedules(DayOfWeek.MONDAY)));
-		return mentoringService.createMentoring(command);
-	}
+  private UUID saveMentoring(String title, int price) {
+    MentoringCategory category = createAndSaveCategory();
+    MentoringCommand.Create command =
+        new MentoringCommand.Create(
+            MENTOR_ID,
+            MENTOR_NAME,
+            MENTOR_FIELD,
+            MENTOR_EMAIL,
+            MENTOR_TYPE,
+            category.getMentoringCategoryId().categoryId(),
+            title,
+            SUBTITLE,
+            DESCRIPTION,
+            DURATION,
+            MentoringType.ONE_ON_ONE,
+            Format.SINGLE,
+            SESSION_COUNT,
+            MAX_PARTICIPANTS,
+            false,
+            price,
+            null,
+            List.of(sessionSlot(SESSION_DATE_1)),
+            List.of(timeSchedules(DayOfWeek.MONDAY)));
+    return mentoringService.createMentoring(command);
+  }
 
-	private void saveMentoringWithMentor(UUID mentorId, String title) {
-		MentoringCategory category = createAndSaveCategory();
-		MentoringCommand.Create command =
-				new MentoringCommand.Create(mentorId, "다른멘토", MENTOR_FIELD, MENTOR_EMAIL,
-						MENTOR_TYPE, category.getMentoringCategoryId()
-						.categoryId(), title, SUBTITLE, DESCRIPTION, DURATION,
-						MentoringType.ONE_ON_ONE, Format.SINGLE, SESSION_COUNT, MAX_PARTICIPANTS,
-						false, PRICE, null, List.of(sessionSlot(SESSION_DATE_1)),
-						List.of(timeSchedules(DayOfWeek.MONDAY)));
-		mentoringService.createMentoring(command);
-	}
+  private void saveMentoringWithMentor(UUID mentorId, String title) {
+    MentoringCategory category = createAndSaveCategory();
+    MentoringCommand.Create command =
+        new MentoringCommand.Create(
+            mentorId,
+            "다른멘토",
+            MENTOR_FIELD,
+            MENTOR_EMAIL,
+            MENTOR_TYPE,
+            category.getMentoringCategoryId().categoryId(),
+            title,
+            SUBTITLE,
+            DESCRIPTION,
+            DURATION,
+            MentoringType.ONE_ON_ONE,
+            Format.SINGLE,
+            SESSION_COUNT,
+            MAX_PARTICIPANTS,
+            false,
+            PRICE,
+            null,
+            List.of(sessionSlot(SESSION_DATE_1)),
+            List.of(timeSchedules(DayOfWeek.MONDAY)));
+    mentoringService.createMentoring(command);
+  }
 }

--- a/src/test/java/com/goggles/mentoring_service/application/service/MentoringServiceTest.java
+++ b/src/test/java/com/goggles/mentoring_service/application/service/MentoringServiceTest.java
@@ -1,5 +1,12 @@
 package com.goggles.mentoring_service.application.service;
 
+import static com.goggles.mentoring_service.domain.mentoring.MentoringFixture.*;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+
 import com.goggles.common.pagination.CommonPageRequest;
 import com.goggles.mentoring_service.application.command.MentoringCommand;
 import com.goggles.mentoring_service.application.result.MentoringResult;
@@ -10,6 +17,10 @@ import com.goggles.mentoring_service.domain.category.repository.MentoringCategor
 import com.goggles.mentoring_service.domain.mentoring.*;
 import com.goggles.mentoring_service.domain.mentoring.exception.MentoringNotFoundException;
 import com.goggles.mentoring_service.domain.mentoring.repository.MentoringRepository;
+import java.time.DayOfWeek;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -21,214 +32,191 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
 
-import java.time.DayOfWeek;
-import java.util.List;
-import java.util.Optional;
-import java.util.UUID;
-
-import static com.goggles.mentoring_service.domain.mentoring.MentoringFixture.*;
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.BDDMockito.given;
-import static org.mockito.Mockito.verify;
-
 @ExtendWith(MockitoExtension.class)
 class MentoringServiceTest {
 
-	private static final Logger log = LoggerFactory.getLogger(MentoringServiceTest.class);
+  private static final Logger log = LoggerFactory.getLogger(MentoringServiceTest.class);
 
-	@InjectMocks
-	private MentoringService mentoringService;
+  @InjectMocks private MentoringService mentoringService;
 
-	@Mock
-	private MentoringRepository mentoringRepository;
+  @Mock private MentoringRepository mentoringRepository;
 
-	@Mock
-	private MentoringCategoryRepository categoryRepository;
+  @Mock private MentoringCategoryRepository categoryRepository;
 
-	@Mock
-	private MentoringCategory category;
+  @Mock private MentoringCategory category;
 
-	@Mock
-	private MentoringCategoryId mockCategoryId;
+  @Mock private MentoringCategoryId mockCategoryId;
 
+  @Test
+  void createMentoring_success() {
+    given(categoryRepository.findById(any())).willReturn(Optional.of(category));
+    given(category.getMentoringCategoryId()).willReturn(mockCategoryId);
+    given(mockCategoryId.categoryId()).willReturn(CATEGORY_ID);
+    given(category.getName()).willReturn(CATEGORY_NAME);
+    given(category.getCode()).willReturn(CATEGORY_CODE);
 
-	@Test
-	void createMentoring_success() {
-		given(categoryRepository.findById(any())).willReturn(Optional.of(category));
-		given(category.getMentoringCategoryId()).willReturn(mockCategoryId);
-		given(mockCategoryId.categoryId()).willReturn(CATEGORY_ID);
-		given(category.getName()).willReturn(CATEGORY_NAME);
-		given(category.getCode()).willReturn(CATEGORY_CODE);
+    UUID result = mentoringService.createMentoring(defaultCommand());
 
-		UUID result = mentoringService.createMentoring(defaultCommand());
+    assertThat(result).isNotNull();
+    verify(mentoringRepository).save(any());
+  }
 
-		assertThat(result).isNotNull();
-		verify(mentoringRepository).save(any());
-	}
+  @Test
+  void createMentoring_category_not_found() {
+    given(categoryRepository.findById(any())).willReturn(Optional.empty());
 
-	@Test
-	void createMentoring_category_not_found() {
-		given(categoryRepository.findById(any())).willReturn(Optional.empty());
+    assertThatThrownBy(() -> mentoringService.createMentoring(defaultCommand()))
+        .isInstanceOf(CategoryNotFoundException.class);
+  }
 
-		assertThatThrownBy(() -> mentoringService.createMentoring(defaultCommand())).isInstanceOf(
-				CategoryNotFoundException.class);
-	}
+  @Test
+  void getMentoring_success() {
+    Mentoring mentoring = defaultMentoringBuilder().build();
+    given(mentoringRepository.findById(any())).willReturn(Optional.of(mentoring));
 
+    UUID id = mentoring.getMentoringId().mentoringId();
+    MentoringResult.Detail result = mentoringService.getMentoring(id);
 
-	@Test
-	void getMentoring_success() {
-		Mentoring mentoring = defaultMentoringBuilder().build();
-		given(mentoringRepository.findById(any())).willReturn(Optional.of(mentoring));
+    log.info("==== 멘토링 상세 조회 결과 ====");
+    log.info("id       : {}", result.mentoringId());
+    log.info("title    : {}", result.title());
+    log.info("status   : {}", result.status());
+    log.info("price    : {}원", result.price());
+    log.info("mentor   : {} / {}", result.mentor().name(), result.mentor().field());
+    log.info("category : {} ({})", result.category().name(), result.category().code());
 
-		UUID id = mentoring.getMentoringId()
-				.mentoringId();
-		MentoringResult.Detail result = mentoringService.getMentoring(id);
+    assertThat(result.mentoringId()).isEqualTo(id);
+    assertThat(result.title()).isEqualTo(TITLE);
+    assertThat(result.status()).isEqualTo(MentoringStatus.INACTIVE);
+    assertThat(result.price()).isEqualTo(PRICE);
+    assertThat(result.mentor().name()).isEqualTo(MENTOR_NAME);
+    assertThat(result.mentor().field()).isEqualTo(MENTOR_FIELD);
+    assertThat(result.category().name()).isEqualTo(CATEGORY_NAME);
+    assertThat(result.category().code()).isEqualTo(CATEGORY_CODE);
+  }
 
-		log.info("==== 멘토링 상세 조회 결과 ====");
-		log.info("id       : {}", result.mentoringId());
-		log.info("title    : {}", result.title());
-		log.info("status   : {}", result.status());
-		log.info("price    : {}원", result.price());
-		log.info("mentor   : {} / {}", result.mentor()
-				.name(), result.mentor()
-				.field());
-		log.info("category : {} ({})", result.category()
-				.name(), result.category()
-				.code());
+  @Test
+  void getMentoring_not_found() {
+    UUID unknownId = UUID.randomUUID();
+    given(mentoringRepository.findById(any())).willReturn(Optional.empty());
 
-		assertThat(result.mentoringId()).isEqualTo(id);
-		assertThat(result.title()).isEqualTo(TITLE);
-		assertThat(result.status()).isEqualTo(MentoringStatus.INACTIVE);
-		assertThat(result.price()).isEqualTo(PRICE);
-		assertThat(result.mentor()
-				.name()).isEqualTo(MENTOR_NAME);
-		assertThat(result.mentor()
-				.field()).isEqualTo(MENTOR_FIELD);
-		assertThat(result.category()
-				.name()).isEqualTo(CATEGORY_NAME);
-		assertThat(result.category()
-				.code()).isEqualTo(CATEGORY_CODE);
-	}
+    log.info("존재하지 않는 멘토링 조회 시도: {}", unknownId);
+    assertThatThrownBy(() -> mentoringService.getMentoring(unknownId))
+        .isInstanceOf(MentoringNotFoundException.class);
+    log.info("MentoringNotFoundException 발생 확인");
+  }
 
-	@Test
-	void getMentoring_not_found() {
-		UUID unknownId = UUID.randomUUID();
-		given(mentoringRepository.findById(any())).willReturn(Optional.empty());
+  @Test
+  void getMentoringSchedules_success() {
+    Mentoring mentoring =
+        defaultMentoringBuilder()
+            .repeatPatterns(
+                List.of(repeatPattern(DayOfWeek.MONDAY), repeatPattern(DayOfWeek.WEDNESDAY)))
+            .sessions(List.of(session(SESSION_DATE_1), session(SESSION_DATE_2)))
+            .build();
+    given(mentoringRepository.findById(any())).willReturn(Optional.of(mentoring));
 
-		log.info("존재하지 않는 멘토링 조회 시도: {}", unknownId);
-		assertThatThrownBy(() -> mentoringService.getMentoring(unknownId)).isInstanceOf(
-				MentoringNotFoundException.class);
-		log.info("MentoringNotFoundException 발생 확인");
-	}
+    MentoringResult.Schedules result =
+        mentoringService.getMentoringSchedules(mentoring.getMentoringId().mentoringId());
 
+    log.info("==== 멘토링 스케쥴 조회 결과 ====");
+    log.info("반복 패턴 ({}):", result.repeatPatterns().size());
+    result
+        .repeatPatterns()
+        .forEach(p -> log.info("  {} {} ~ {}", p.dayOfWeek(), p.startTime(), p.endTime()));
+    log.info("세션 ({}):", result.sessions().size());
+    result
+        .sessions()
+        .forEach(
+            s -> log.info("  {} {} ~ {} [{}]", s.date(), s.startTime(), s.endTime(), s.status()));
 
-	@Test
-	void getMentoringSchedules_success() {
-		Mentoring mentoring = defaultMentoringBuilder().repeatPatterns(
-						List.of(repeatPattern(DayOfWeek.MONDAY), repeatPattern(DayOfWeek.WEDNESDAY)))
-				.sessions(List.of(session(SESSION_DATE_1), session(SESSION_DATE_2)))
-				.build();
-		given(mentoringRepository.findById(any())).willReturn(Optional.of(mentoring));
+    assertThat(result.repeatPatterns()).hasSize(2);
+    assertThat(result.repeatPatterns().get(0).dayOfWeek()).isEqualTo(DayOfWeek.MONDAY);
+    assertThat(result.repeatPatterns().get(1).dayOfWeek()).isEqualTo(DayOfWeek.WEDNESDAY);
+    assertThat(result.sessions()).hasSize(2);
+    assertThat(result.sessions().get(0).date()).isEqualTo(SESSION_DATE_1);
+    assertThat(result.sessions().get(1).date()).isEqualTo(SESSION_DATE_2);
+  }
 
-		MentoringResult.Schedules result = mentoringService.getMentoringSchedules(
-				mentoring.getMentoringId()
-						.mentoringId());
+  @Test
+  void getMentoringSchedules_not_found() {
+    UUID unknownId = UUID.randomUUID();
+    given(mentoringRepository.findById(any())).willReturn(Optional.empty());
 
-		log.info("==== 멘토링 스케쥴 조회 결과 ====");
-		log.info("반복 패턴 ({}):", result.repeatPatterns()
-				.size());
-		result.repeatPatterns()
-				.forEach(p -> log.info("  {} {} ~ {}", p.dayOfWeek(), p.startTime(), p.endTime()));
-		log.info("세션 ({}):", result.sessions()
-				.size());
-		result.sessions()
-				.forEach(s -> log.info("  {} {} ~ {} [{}]", s.date(), s.startTime(), s.endTime(),
-						s.status()));
+    log.info("존재하지 않는 멘토링 스케쥴 조회 시도: {}", unknownId);
+    assertThatThrownBy(() -> mentoringService.getMentoringSchedules(unknownId))
+        .isInstanceOf(MentoringNotFoundException.class);
+    log.info("MentoringNotFoundException 발생 확인");
+  }
 
-		assertThat(result.repeatPatterns()).hasSize(2);
-		assertThat(result.repeatPatterns()
-				.get(0)
-				.dayOfWeek()).isEqualTo(DayOfWeek.MONDAY);
-		assertThat(result.repeatPatterns()
-				.get(1)
-				.dayOfWeek()).isEqualTo(DayOfWeek.WEDNESDAY);
-		assertThat(result.sessions()).hasSize(2);
-		assertThat(result.sessions()
-				.get(0)
-				.date()).isEqualTo(SESSION_DATE_1);
-		assertThat(result.sessions()
-				.get(1)
-				.date()).isEqualTo(SESSION_DATE_2);
-	}
+  @Test
+  void searchMentorings_success() {
+    Mentoring m1 = defaultMentoringBuilder().build();
+    Mentoring m2 = defaultMentoringBuilder().title("리액트 멘토링").price(30_000).build();
+    Page<Mentoring> page = new PageImpl<>(List.of(m1, m2), PageRequest.of(0, 10), 2);
+    given(mentoringRepository.findAll(any(), any())).willReturn(page);
 
-	@Test
-	void getMentoringSchedules_not_found() {
-		UUID unknownId = UUID.randomUUID();
-		given(mentoringRepository.findById(any())).willReturn(Optional.empty());
+    MentoringSearchCondition condition =
+        new MentoringSearchCondition(null, null, null, null, null, null);
+    Page<MentoringResult.Summary> result =
+        mentoringService.searchMentorings(condition, CommonPageRequest.of(0, 10));
 
-		log.info("존재하지 않는 멘토링 스케쥴 조회 시도: {}", unknownId);
-		assertThatThrownBy(() -> mentoringService.getMentoringSchedules(unknownId)).isInstanceOf(
-				MentoringNotFoundException.class);
-		log.info("MentoringNotFoundException 발생 확인");
-	}
+    log.info("==== 멘토링 목록 조회 결과 ====");
+    log.info("총 {}건 / {}페이지", result.getTotalElements(), result.getTotalPages());
+    result
+        .getContent()
+        .forEach(
+            s ->
+                log.info(
+                    "  [{}] {} | {}원 | 멘토: {} | 카테고리: {}",
+                    s.status(),
+                    s.title(),
+                    s.price(),
+                    s.mentorName(),
+                    s.categoryName()));
 
+    assertThat(result.getTotalElements()).isEqualTo(2);
+    assertThat(result.getContent()).hasSize(2);
+    assertThat(result.getContent().get(0).title()).isEqualTo(TITLE);
+    assertThat(result.getContent().get(1).title()).isEqualTo("리액트 멘토링");
+    assertThat(result.getContent().get(1).price()).isEqualTo(30_000);
+  }
 
-	@Test
-	void searchMentorings_returns_page_of_summaries() {
-		Mentoring m1 = defaultMentoringBuilder().build();
-		Mentoring m2 = defaultMentoringBuilder().title("리액트 멘토링")
-				.price(30_000)
-				.build();
-		Page<Mentoring> page = new PageImpl<>(List.of(m1, m2), PageRequest.of(0, 10), 2);
-		given(mentoringRepository.findAll(any(), any())).willReturn(page);
+  @Test
+  void searchMentorings_empty_result() {
+    Page<Mentoring> emptyPage = new PageImpl<>(List.of(), PageRequest.of(0, 10), 0);
+    given(mentoringRepository.findAll(any(), any())).willReturn(emptyPage);
 
-		MentoringSearchCondition condition =
-				new MentoringSearchCondition(null, null, null, null, null, null);
-		Page<MentoringResult.Summary> result =
-				mentoringService.searchMentorings(condition, CommonPageRequest.of(0, 10));
+    MentoringSearchCondition condition =
+        new MentoringSearchCondition("없는키워드", null, null, null, null, null);
+    Page<MentoringResult.Summary> result =
+        mentoringService.searchMentorings(condition, CommonPageRequest.of(0, 10));
 
-		log.info("==== 멘토링 목록 조회 결과 ====");
-		log.info("총 {}건 / {}페이지", result.getTotalElements(), result.getTotalPages());
-		result.getContent()
-				.forEach(s -> log.info("  [{}] {} | {}원 | 멘토: {} | 카테고리: {}", s.status(), s.title(),
-						s.price(), s.mentorName(), s.categoryName()));
+    log.info("키워드 '{}' 검색 결과: {}건", condition.keyword(), result.getTotalElements());
+    assertThat(result.getContent()).isEmpty();
+    assertThat(result.getTotalElements()).isZero();
+  }
 
-		assertThat(result.getTotalElements()).isEqualTo(2);
-		assertThat(result.getContent()).hasSize(2);
-		assertThat(result.getContent()
-				.get(0)
-				.title()).isEqualTo(TITLE);
-		assertThat(result.getContent()
-				.get(1)
-				.title()).isEqualTo("리액트 멘토링");
-		assertThat(result.getContent()
-				.get(1)
-				.price()).isEqualTo(30_000);
-	}
-
-	@Test
-	void searchMentorings_returns_empty_when_no_results() {
-		Page<Mentoring> emptyPage = new PageImpl<>(List.of(), PageRequest.of(0, 10), 0);
-		given(mentoringRepository.findAll(any(), any())).willReturn(emptyPage);
-
-		MentoringSearchCondition condition =
-				new MentoringSearchCondition("없는키워드", null, null, null, null, null);
-		Page<MentoringResult.Summary> result =
-				mentoringService.searchMentorings(condition, CommonPageRequest.of(0, 10));
-
-		log.info("키워드 '{}' 검색 결과: {}건", condition.keyword(), result.getTotalElements());
-		assertThat(result.getContent()).isEmpty();
-		assertThat(result.getTotalElements()).isZero();
-	}
-
-
-	private MentoringCommand.Create defaultCommand() {
-		return new MentoringCommand.Create(MENTOR_ID, MENTOR_NAME, MENTOR_FIELD, MENTOR_EMAIL,
-				MENTOR_TYPE, CATEGORY_ID, TITLE, SUBTITLE, DESCRIPTION, DURATION,
-				MentoringType.ONE_ON_ONE, Format.SINGLE, SESSION_COUNT, MAX_PARTICIPANTS, false,
-				PRICE, null, List.of(sessionSlot(SESSION_DATE_1)),
-				List.of(timeSchedules(DayOfWeek.MONDAY)));
-	}
+  private MentoringCommand.Create defaultCommand() {
+    return new MentoringCommand.Create(
+        MENTOR_ID,
+        MENTOR_NAME,
+        MENTOR_FIELD,
+        MENTOR_EMAIL,
+        MENTOR_TYPE,
+        CATEGORY_ID,
+        TITLE,
+        SUBTITLE,
+        DESCRIPTION,
+        DURATION,
+        MentoringType.ONE_ON_ONE,
+        Format.SINGLE,
+        SESSION_COUNT,
+        MAX_PARTICIPANTS,
+        false,
+        PRICE,
+        null,
+        List.of(sessionSlot(SESSION_DATE_1)),
+        List.of(timeSchedules(DayOfWeek.MONDAY)));
+  }
 }

--- a/src/test/java/com/goggles/mentoring_service/domain/booking/BookingFixture.java
+++ b/src/test/java/com/goggles/mentoring_service/domain/booking/BookingFixture.java
@@ -1,0 +1,60 @@
+package com.goggles.mentoring_service.domain.booking;
+
+import static com.goggles.mentoring_service.domain.mentoring.MentoringFixture.*;
+
+import com.goggles.mentoring_service.domain._common.UserType;
+import com.goggles.mentoring_service.domain.mentoring.Mentoring;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.util.List;
+import java.util.UUID;
+
+public class BookingFixture {
+
+  public static final UUID MENTEE_ID = UUID.fromString("00000000-0000-0000-0000-000000000010");
+  public static final String MENTEE_NAME = "김학생";
+  public static final String REQUEST_MESSAGE = "잘 부탁드립니다";
+
+  public static final LocalDate SESSION_DATE = LocalDate.of(2026, 6, 1);
+  public static final LocalDate SESSION_DATE_2 = LocalDate.of(2026, 6, 2);
+  public static final LocalTime SESSION_START_TIME = LocalTime.of(10, 0);
+  public static final LocalTime SESSION_END_TIME = LocalTime.of(11, 0);
+
+  // SESSION_DATE 기준 24시간 전/후 (세션: 2026-06-01 10:00, 취소 마감: 2026-05-31 10:00)
+  public static final LocalDateTime BEFORE_DEADLINE = LocalDateTime.of(2026, 5, 31, 0, 0);
+  public static final LocalDateTime AFTER_DEADLINE = LocalDateTime.of(2026, 6, 1, 9, 1);
+
+  public static final String REJECT_REASON = "일정 불가";
+  public static final String CANCEL_REASON = "개인 사정";
+
+  public static Mentoring mentoring() {
+    return defaultMentoringBuilder().sessions(List.of()).build();
+  }
+
+  public static SessionSlot sessionSlot() {
+    return new SessionSlot(SESSION_DATE, SESSION_START_TIME, SESSION_END_TIME);
+  }
+
+  public static SessionSlot sessionSlot2() {
+    return new SessionSlot(SESSION_DATE_2, SESSION_START_TIME, SESSION_END_TIME);
+  }
+
+  public static MentoringBooking pendingBooking() {
+    return MentoringBooking.create(
+        MENTEE_ID, UserType.STUDENT, MENTEE_NAME,
+        mentoring(), List.of(sessionSlot()), REQUEST_MESSAGE, null);
+  }
+
+  public static MentoringBooking paymentCompletedBooking() {
+    MentoringBooking booking = pendingBooking();
+    booking.completePayment();
+    return booking;
+  }
+
+  public static MentoringBooking acceptedBooking() {
+    MentoringBooking booking = paymentCompletedBooking();
+    booking.accept(MENTOR_ID, UserType.INSTRUCTOR);
+    return booking;
+  }
+}

--- a/src/test/java/com/goggles/mentoring_service/domain/booking/MentoringBookingTest.java
+++ b/src/test/java/com/goggles/mentoring_service/domain/booking/MentoringBookingTest.java
@@ -58,7 +58,7 @@ class MentoringBookingTest {
   @Test
   void failPayment_success() {
     MentoringBooking booking = pendingBooking();
-    booking.failPayment( "결제 실패 사유");
+    booking.failPayment( "결제 실패 사유", LocalDateTime.now());
 
     assertThat(booking.getStatus()).isEqualTo(BookingStatus.PAYMENT_FAILED);
   }

--- a/src/test/java/com/goggles/mentoring_service/domain/booking/MentoringBookingTest.java
+++ b/src/test/java/com/goggles/mentoring_service/domain/booking/MentoringBookingTest.java
@@ -1,0 +1,189 @@
+package com.goggles.mentoring_service.domain.booking;
+
+import static com.goggles.mentoring_service.domain.booking.BookingFixture.*;
+import static com.goggles.mentoring_service.domain.mentoring.MentoringFixture.MENTOR_ID;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.goggles.mentoring_service.domain._common.UserType;
+import com.goggles.mentoring_service.domain.booking.exception.CancellationDeadlineExceededException;
+import com.goggles.mentoring_service.domain.booking.exception.CancellationReasonRequiredException;
+import com.goggles.mentoring_service.domain.booking.exception.InvalidBookingStatusTransitionException;
+import com.goggles.mentoring_service.domain.booking.exception.UnauthorizedBookingAccessException;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+
+class MentoringBookingTest {
+
+  @Test
+  void create_success() {
+    MentoringBooking booking = pendingBooking();
+
+    assertThat(booking.getMentoringBookingId()).isNotNull();
+    assertThat(booking.getStatus()).isEqualTo(BookingStatus.PENDING);
+  }
+
+  @Test
+  void create_with_multiple_sessions() {
+    MentoringBooking booking =
+        MentoringBooking.create(
+            MENTEE_ID, UserType.STUDENT, MENTEE_NAME,
+            mentoring(), List.of(sessionSlot(), sessionSlot2()), REQUEST_MESSAGE, UUID.randomUUID());
+
+    assertThat(booking.getStatus()).isEqualTo(BookingStatus.PENDING);
+  }
+
+  @Test
+  void mentee_must_be_student() {
+    UUID instructorId = UUID.randomUUID();
+
+    assertThatThrownBy(
+            () ->
+                MentoringBooking.create(
+                    instructorId, UserType.INSTRUCTOR, "이강사",
+                    mentoring(), List.of(sessionSlot()), REQUEST_MESSAGE, UUID.randomUUID()))
+        .isInstanceOf(RuntimeException.class);
+  }
+
+  @Test
+  void completePayment_success() {
+    MentoringBooking booking = pendingBooking();
+    booking.completePayment();
+
+    assertThat(booking.getStatus()).isEqualTo(BookingStatus.PAYMENT_COMPLETED);
+  }
+
+  @Test
+  void failPayment_success() {
+    MentoringBooking booking = pendingBooking();
+    booking.failPayment( "결제 실패 사유");
+
+    assertThat(booking.getStatus()).isEqualTo(BookingStatus.PAYMENT_FAILED);
+  }
+
+  @Test
+  void completePayment_from_invalid_status() {
+    MentoringBooking booking = paymentCompletedBooking();
+
+    assertThatThrownBy(booking::completePayment)
+        .isInstanceOf(InvalidBookingStatusTransitionException.class);
+  }
+
+  @Test
+  void accept_success() {
+    MentoringBooking booking = paymentCompletedBooking();
+    booking.accept(MENTOR_ID, UserType.INSTRUCTOR);
+
+    assertThat(booking.getStatus()).isEqualTo(BookingStatus.ACCEPTED);
+  }
+
+  @Test
+  void accept_by_non_mentor() {
+    MentoringBooking booking = paymentCompletedBooking();
+
+    assertThatThrownBy(() -> booking.accept(UUID.randomUUID(), UserType.INSTRUCTOR))
+        .isInstanceOf(UnauthorizedBookingAccessException.class);
+  }
+
+  @Test
+  void accept_by_student() {
+    MentoringBooking booking = paymentCompletedBooking();
+
+    assertThatThrownBy(() -> booking.accept(MENTEE_ID, UserType.STUDENT))
+        .isInstanceOf(UnauthorizedBookingAccessException.class);
+  }
+
+  @Test
+  void accept_from_pending_status() {
+    MentoringBooking booking = pendingBooking();
+
+    assertThatThrownBy(() -> booking.accept(MENTOR_ID, UserType.INSTRUCTOR))
+        .isInstanceOf(InvalidBookingStatusTransitionException.class);
+  }
+
+  @Test
+  void reject_success() {
+    MentoringBooking booking = paymentCompletedBooking();
+    booking.reject(MENTOR_ID, UserType.INSTRUCTOR, REJECT_REASON, LocalDateTime.now());
+
+    assertThat(booking.getStatus()).isEqualTo(BookingStatus.REJECTED);
+    assertThat(booking.getCloseReason()).isEqualTo(REJECT_REASON);
+    assertThat(booking.getClosedBy()).isEqualTo(MENTOR_ID);
+  }
+
+  @Test
+  void reject_without_reason() {
+    MentoringBooking booking = paymentCompletedBooking();
+
+    assertThatThrownBy(
+            () -> booking.reject(MENTOR_ID, UserType.INSTRUCTOR, "", LocalDateTime.now()))
+        .isInstanceOf(CancellationReasonRequiredException.class);
+  }
+
+  @Test
+  void reject_by_non_mentor() {
+    MentoringBooking booking = paymentCompletedBooking();
+
+    assertThatThrownBy(
+            () ->
+                booking.reject(
+                    UUID.randomUUID(), UserType.INSTRUCTOR, REJECT_REASON, LocalDateTime.now()))
+        .isInstanceOf(UnauthorizedBookingAccessException.class);
+  }
+
+  @Test
+  void cancel_by_mentee_success() {
+    MentoringBooking booking = paymentCompletedBooking();
+    booking.cancel(MENTEE_ID, UserType.STUDENT, CANCEL_REASON, BEFORE_DEADLINE);
+
+    assertThat(booking.getStatus()).isEqualTo(BookingStatus.CANCELED);
+    assertThat(booking.getClosedBy()).isEqualTo(MENTEE_ID);
+  }
+
+  @Test
+  void cancel_by_mentor_success() {
+    MentoringBooking booking = acceptedBooking();
+    booking.cancel(MENTOR_ID, UserType.INSTRUCTOR, CANCEL_REASON, BEFORE_DEADLINE);
+
+    assertThat(booking.getStatus()).isEqualTo(BookingStatus.CANCELED);
+  }
+
+  @Test
+  void cancel_without_reason() {
+    MentoringBooking booking = paymentCompletedBooking();
+
+    assertThatThrownBy(() -> booking.cancel(MENTEE_ID, UserType.STUDENT, "", BEFORE_DEADLINE))
+        .isInstanceOf(CancellationReasonRequiredException.class);
+  }
+
+  @Test
+  void cancel_after_deadline() {
+    MentoringBooking booking = paymentCompletedBooking();
+
+    assertThatThrownBy(
+            () -> booking.cancel(MENTEE_ID, UserType.STUDENT, CANCEL_REASON, AFTER_DEADLINE))
+        .isInstanceOf(CancellationDeadlineExceededException.class);
+  }
+
+  @Test
+  void cancel_by_unauthorized_user() {
+    MentoringBooking booking = paymentCompletedBooking();
+
+    assertThatThrownBy(
+            () ->
+                booking.cancel(UUID.randomUUID(), UserType.STUDENT, CANCEL_REASON, BEFORE_DEADLINE))
+        .isInstanceOf(UnauthorizedBookingAccessException.class);
+  }
+
+  @Test
+  void cancel_already_rejected() {
+    MentoringBooking booking = paymentCompletedBooking();
+    booking.reject(MENTOR_ID, UserType.INSTRUCTOR, REJECT_REASON, LocalDateTime.now());
+
+    assertThatThrownBy(
+            () -> booking.cancel(MENTEE_ID, UserType.STUDENT, CANCEL_REASON, BEFORE_DEADLINE))
+        .isInstanceOf(InvalidBookingStatusTransitionException.class);
+  }
+}

--- a/src/test/java/com/goggles/mentoring_service/domain/mentoring/MentoringFixture.java
+++ b/src/test/java/com/goggles/mentoring_service/domain/mentoring/MentoringFixture.java
@@ -1,9 +1,8 @@
 package com.goggles.mentoring_service.domain.mentoring;
 
-import com.goggles.mentoring_service.application.command.SessionSlot;
 import com.goggles.mentoring_service.application.command.TimeSchedules;
 import com.goggles.mentoring_service.domain._common.UserType;
-
+import com.goggles.mentoring_service.domain.booking.SessionSlot;
 import java.time.DayOfWeek;
 import java.time.LocalDate;
 import java.time.LocalTime;
@@ -12,68 +11,69 @@ import java.util.UUID;
 
 public class MentoringFixture {
 
-	public static final UUID MENTOR_ID = UUID.fromString("00000000-0000-0000-0000-000000000001");
-	public static final String MENTOR_NAME = "홍길동";
-	public static final String MENTOR_FIELD = "백엔드";
-	public static final String MENTOR_EMAIL = "mentor@test.com";
-	public static final UserType MENTOR_TYPE = UserType.INSTRUCTOR;
+  public static final UUID MENTORING_ID = UUID.fromString("00000000-0000-0000-0000-000000000003");
+  public static final UUID MENTOR_ID = UUID.fromString("00000000-0000-0000-0000-000000000001");
+  public static final String MENTOR_NAME = "홍길동";
+  public static final String MENTOR_FIELD = "백엔드";
+  public static final String MENTOR_EMAIL = "mentor@test.com";
+  public static final UserType MENTOR_TYPE = UserType.INSTRUCTOR;
 
-	public static final UUID CATEGORY_ID = UUID.fromString("00000000-0000-0000-0000-000000000002");
-	public static final String CATEGORY_NAME = "자바";
-	public static final String CATEGORY_CODE = "JAVA";
+  public static final UUID CATEGORY_ID = UUID.fromString("00000000-0000-0000-0000-000000000002");
+  public static final String CATEGORY_NAME = "자바";
+  public static final String CATEGORY_CODE = "JAVA";
 
-	public static final String TITLE = "스프링 부트 멘토링";
-	public static final String SUBTITLE = "실무 위주";
-	public static final String DESCRIPTION = "멘토링 설명";
-	public static final MentoringDuration DURATION = MentoringDuration.MINUTES_60;
-	public static final int SESSION_COUNT = 1;
-	public static final int MAX_PARTICIPANTS = 1;
-	public static final int PRICE = 50_000;
+  public static final String TITLE = "스프링 부트 멘토링";
+  public static final String SUBTITLE = "실무 위주";
+  public static final String DESCRIPTION = "멘토링 설명";
+  public static final MentoringDuration DURATION = MentoringDuration.MINUTES_60;
+  public static final int SESSION_COUNT = 1;
+  public static final int MAX_PARTICIPANTS = 1;
+  public static final int PRICE = 50_000;
 
-	public static final LocalDate SESSION_DATE_1 = LocalDate.of(2026, 5, 1);
-	public static final LocalDate SESSION_DATE_2 = LocalDate.of(2026, 5, 2);
-	public static final LocalTime START_TIME = LocalTime.of(10, 0);
-	public static final LocalTime END_TIME = LocalTime.of(11, 0);
+  public static final LocalDate SESSION_DATE_1 = LocalDate.of(2026, 5, 1);
+  public static final LocalDate SESSION_DATE_2 = LocalDate.of(2026, 5, 2);
+  public static final LocalTime START_TIME = LocalTime.of(10, 0);
+  public static final LocalTime END_TIME = LocalTime.of(11, 0);
 
-	public static Mentoring.MentoringBuilder defaultMentoringBuilder() {
-		return Mentoring.builder()
-				.mentorId(MENTOR_ID)
-				.mentorName(MENTOR_NAME)
-				.mentorField(MENTOR_FIELD)
-				.mentorEmail(MENTOR_EMAIL)
-				.mentorType(MENTOR_TYPE)
-				.categoryId(CATEGORY_ID)
-				.categoryName(CATEGORY_NAME)
-				.categoryCode(CATEGORY_CODE)
-				.title(TITLE)
-				.subtitle(SUBTITLE)
-				.description(DESCRIPTION)
-				.duration(DURATION)
-				.status(MentoringStatus.INACTIVE)
-				.mentoringType(MentoringType.ONE_ON_ONE)
-				.format(Format.SINGLE)
-				.sessionCount(SESSION_COUNT)
-				.maxParticipants(MAX_PARTICIPANTS)
-				.excludeHolidays(false)
-				.price(PRICE)
-				.endDate(null)
-				.sessions(List.of())
-				.repeatPatterns(List.of());
-	}
+  public static Mentoring.MentoringBuilder defaultMentoringBuilder() {
+    return Mentoring.builder()
+        .mentorId(MENTOR_ID)
+        .mentorName(MENTOR_NAME)
+        .mentorField(MENTOR_FIELD)
+        .mentorEmail(MENTOR_EMAIL)
+        .mentorType(MENTOR_TYPE)
+        .categoryId(CATEGORY_ID)
+        .categoryName(CATEGORY_NAME)
+        .categoryCode(CATEGORY_CODE)
+        .title(TITLE)
+        .subtitle(SUBTITLE)
+        .description(DESCRIPTION)
+        .duration(DURATION)
+        .status(MentoringStatus.INACTIVE)
+        .mentoringType(MentoringType.ONE_ON_ONE)
+        .format(Format.SINGLE)
+        .sessionCount(SESSION_COUNT)
+        .maxParticipants(MAX_PARTICIPANTS)
+        .excludeHolidays(false)
+        .price(PRICE)
+        .endDate(null)
+        .sessions(List.of())
+        .repeatPatterns(List.of());
+  }
 
-	public static MentoringSession session(LocalDate date) {
-		return MentoringSession.of(date, START_TIME, END_TIME);
-	}
+  public static MentoringSession session(LocalDate date) {
+    return MentoringSession.of(date, START_TIME, END_TIME);
+  }
 
-	public static SessionSlot sessionSlot(LocalDate date) {
-		return new SessionSlot(date, START_TIME, END_TIME);
-	}
+  public static SessionSlot sessionSlot(LocalDate date) {
+    return new SessionSlot(date, START_TIME, END_TIME);
+  }
 
-	public static RepeatPattern repeatPattern(DayOfWeek dayOfWeek) {
-		return RepeatPattern.of(dayOfWeek, START_TIME, END_TIME);
-	}
+  public static RepeatPattern repeatPattern(DayOfWeek dayOfWeek) {
+    return RepeatPattern.of(dayOfWeek, START_TIME, END_TIME);
+  }
 
-	public static TimeSchedules timeSchedules(DayOfWeek dayOfWeek) {
-		return new TimeSchedules(dayOfWeek, START_TIME, END_TIME);
-	}
+  public static TimeSchedules timeSchedules(DayOfWeek dayOfWeek) {
+    return new TimeSchedules(dayOfWeek, START_TIME, END_TIME);
+  }
 }

--- a/src/test/java/com/goggles/mentoring_service/presentation/AdminControllerTest.java
+++ b/src/test/java/com/goggles/mentoring_service/presentation/AdminControllerTest.java
@@ -1,22 +1,5 @@
 package com.goggles.mentoring_service.presentation;
 
-import com.goggles.common.exception.ForbiddenException;
-import com.goggles.mentoring_service.application.result.CategoryResult;
-import com.goggles.mentoring_service.application.service.CategoryService;
-import com.goggles.mentoring_service.domain._common.UserType;
-import com.goggles.mentoring_service.infrastructure.config.WebMvcConfig;
-import com.goggles.mentoring_service.presentation.support.UserContextArgumentResolver;
-import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.context.annotation.Import;
-import org.springframework.data.jpa.mapping.JpaMetamodelMappingContext;
-import org.springframework.test.context.bean.override.mockito.MockitoBean;
-import org.springframework.test.web.servlet.MockMvc;
-
-import java.util.List;
-import java.util.UUID;
-
 import static com.goggles.mentoring_service.presentation.support.TestHeaders.headersFor;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
@@ -26,62 +9,74 @@ import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import com.goggles.common.exception.ForbiddenException;
+import com.goggles.mentoring_service.application.result.CategoryResult;
+import com.goggles.mentoring_service.application.service.CategoryService;
+import com.goggles.mentoring_service.domain._common.UserType;
+import com.goggles.mentoring_service.infrastructure.config.WebMvcConfig;
+import com.goggles.mentoring_service.presentation.support.UserContextArgumentResolver;
+import java.util.List;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.data.jpa.mapping.JpaMetamodelMappingContext;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
 @WebMvcTest(AdminController.class)
 @Import({WebMvcConfig.class, UserContextArgumentResolver.class})
 @MockitoBean(types = JpaMetamodelMappingContext.class)
 class AdminControllerTest {
 
-	@Autowired
-	private MockMvc mockMvc;
+  @Autowired private MockMvc mockMvc;
 
-	@MockitoBean
-	private CategoryService categoryService;
+  @MockitoBean private CategoryService categoryService;
 
-	@Test
-	void getAllCategories_returns_200_with_all_categories() throws Exception {
-		UUID activeId = UUID.randomUUID();
-		UUID inactiveId = UUID.randomUUID();
-		String activeName = UUID.randomUUID()
-				.toString();
-		String activeCode = UUID.randomUUID()
-				.toString()
-				.substring(0, 8)
-				.toUpperCase();
+  @Test
+  void getAllCategories_success() throws Exception {
+    UUID activeId = UUID.randomUUID();
+    UUID inactiveId = UUID.randomUUID();
+    String activeName = UUID.randomUUID().toString();
+    String activeCode = UUID.randomUUID().toString().substring(0, 8).toUpperCase();
 
-		given(categoryService.getAllCategories(any())).willReturn(
-				List.of(new CategoryResult.Info(activeId, activeName, activeCode, 0, true),
-						new CategoryResult.Info(inactiveId, UUID.randomUUID()
-								.toString(), UUID.randomUUID()
-								.toString()
-								.substring(0, 8)
-								.toUpperCase(), null, false)));
+    given(categoryService.getAllCategories(any()))
+        .willReturn(
+            List.of(
+                new CategoryResult.Info(activeId, activeName, activeCode, 0, true),
+                new CategoryResult.Info(
+                    inactiveId,
+                    UUID.randomUUID().toString(),
+                    UUID.randomUUID().toString().substring(0, 8).toUpperCase(),
+                    null,
+                    false)));
 
-		mockMvc.perform(
-						get("/api/v1/admin/mentorings-categories").headers(headersFor(UserType.MASTER)))
-				.andDo(print())
-				.andExpect(status().isOk())
-				.andExpect(jsonPath("$.categories").isArray())
-				.andExpect(jsonPath("$.categories.length()").value(2))
-				.andExpect(jsonPath("$.categories[0].categoryId").value(activeId.toString()))
-				.andExpect(jsonPath("$.categories[0].name").value(activeName))
-				.andExpect(jsonPath("$.categories[0].active").value(true))
-				.andExpect(jsonPath("$.categories[0].sortOrder").value(0))
-				.andExpect(jsonPath("$.categories[1].active").value(false))
-				.andExpect(jsonPath("$.categories[1].sortOrder").isEmpty());
-	}
+    mockMvc
+        .perform(get("/api/v1/admin/mentorings-categories").headers(headersFor(UserType.MASTER)))
+        .andDo(print())
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.categories").isArray())
+        .andExpect(jsonPath("$.categories.length()").value(2))
+        .andExpect(jsonPath("$.categories[0].categoryId").value(activeId.toString()))
+        .andExpect(jsonPath("$.categories[0].name").value(activeName))
+        .andExpect(jsonPath("$.categories[0].active").value(true))
+        .andExpect(jsonPath("$.categories[0].sortOrder").value(0))
+        .andExpect(jsonPath("$.categories[1].active").value(false))
+        .andExpect(jsonPath("$.categories[1].sortOrder").isEmpty());
+  }
 
-	@Test
-	void getAllCategories_returns_403_when_not_master() throws Exception {
-		String errorMessage = "관리자 권한이 필요합니다.";
-		willThrow(new ForbiddenException(errorMessage)).given(categoryService)
-				.getAllCategories(any());
+  @Test
+  void getAllCategories_forbidden_if_not_master() throws Exception {
+    String errorMessage = "관리자 권한이 필요합니다.";
+    willThrow(new ForbiddenException(errorMessage)).given(categoryService).getAllCategories(any());
 
-		mockMvc.perform(
-						get("/api/v1/admin/mentorings-categories").headers(headersFor(UserType.INSTRUCTOR)))
-				.andDo(print())
-				.andExpect(status().isForbidden())
-				.andExpect(jsonPath("$.title").value("Forbidden"))
-				.andExpect(jsonPath("$.detail").value(errorMessage));
-	}
-
+    mockMvc
+        .perform(
+            get("/api/v1/admin/mentorings-categories").headers(headersFor(UserType.INSTRUCTOR)))
+        .andDo(print())
+        .andExpect(status().isForbidden())
+        .andExpect(jsonPath("$.title").value("Forbidden"))
+        .andExpect(jsonPath("$.detail").value(errorMessage));
+  }
 }

--- a/src/test/java/com/goggles/mentoring_service/presentation/BookingControllerTest.java
+++ b/src/test/java/com/goggles/mentoring_service/presentation/BookingControllerTest.java
@@ -1,0 +1,107 @@
+package com.goggles.mentoring_service.presentation;
+
+import static com.goggles.mentoring_service.domain.booking.BookingFixture.*;
+import static com.goggles.mentoring_service.domain.mentoring.MentoringFixture.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.goggles.mentoring_service.application.result.BookingResult;
+import com.goggles.mentoring_service.application.service.BookingService;
+import com.goggles.mentoring_service.domain._common.UserType;
+import com.goggles.mentoring_service.domain.booking.MentoringBookingId;
+import com.goggles.mentoring_service.domain.mentoring.MentoringId;
+import com.goggles.mentoring_service.domain.mentoring.exception.MentoringNotFoundException;
+import com.goggles.mentoring_service.infrastructure.config.WebMvcConfig;
+import com.goggles.mentoring_service.presentation.dto.BookingRequest;
+import com.goggles.mentoring_service.presentation.support.TestHeaders;
+import com.goggles.mentoring_service.presentation.support.UserContextArgumentResolver;
+import java.util.List;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.data.jpa.mapping.JpaMetamodelMappingContext;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest(BookingController.class)
+@Import({WebMvcConfig.class, UserContextArgumentResolver.class})
+@MockitoBean(types = JpaMetamodelMappingContext.class)
+class BookingControllerTest {
+
+  @Autowired private MockMvc mockMvc;
+  @Autowired private ObjectMapper objectMapper;
+  @MockitoBean private BookingService bookingService;
+
+  @Test
+  void createBooking_success() throws Exception {
+    UUID bookingId = UUID.randomUUID();
+    given(bookingService.createBooking(any()))
+        .willReturn(BookingResult.Create.of(new MentoringBookingId(bookingId)));
+
+    mockMvc
+        .perform(
+            post("/api/v1/mentoring-bookings")
+                .contentType(MediaType.APPLICATION_JSON)
+                .headers(TestHeaders.headersFor(UserType.STUDENT))
+                .content(objectMapper.writeValueAsString(defaultRequest())))
+        .andDo(print())
+        .andExpect(status().isCreated())
+        .andExpect(jsonPath("$.bookingId").value(bookingId.toString()));
+  }
+
+  @Test
+  void createBooking_fails_without_mentoringId() throws Exception {
+    mockMvc
+        .perform(
+            post("/api/v1/mentoring-bookings")
+                .contentType(MediaType.APPLICATION_JSON)
+                .headers(TestHeaders.headersFor(UserType.STUDENT))
+                .content("{}"))
+        .andExpect(status().isBadRequest());
+  }
+
+  @Test
+  void createBooking_fails_with_empty_slots() throws Exception {
+    BookingRequest.Create request = new BookingRequest.Create(UUID.randomUUID(), List.of(), null,
+            null);
+
+    mockMvc
+        .perform(
+            post("/api/v1/mentoring-bookings")
+                .contentType(MediaType.APPLICATION_JSON)
+                .headers(TestHeaders.headersFor(UserType.STUDENT))
+                .content(objectMapper.writeValueAsString(request)))
+        .andExpect(status().isBadRequest());
+  }
+
+  @Test
+  void createBooking_mentoring_not_found() throws Exception {
+    MentoringId mentoringId = new MentoringId(UUID.randomUUID());
+    given(bookingService.createBooking(any()))
+        .willThrow(new MentoringNotFoundException(mentoringId));
+
+    mockMvc
+        .perform(
+            post("/api/v1/mentoring-bookings")
+                .contentType(MediaType.APPLICATION_JSON)
+                .headers(TestHeaders.headersFor(UserType.STUDENT))
+                .content(objectMapper.writeValueAsString(defaultRequest())))
+        .andDo(print())
+        .andExpect(status().isNotFound())
+        .andExpect(jsonPath("$.title").value("Not Found"));
+  }
+
+  private BookingRequest.Create defaultRequest() {
+    BookingRequest.BookingTimeSlot slot =
+        new BookingRequest.BookingTimeSlot(SESSION_DATE, SESSION_START_TIME, SESSION_END_TIME);
+    return new BookingRequest.Create(MENTOR_ID, List.of(slot), REQUEST_MESSAGE,null);
+  }
+}

--- a/src/test/java/com/goggles/mentoring_service/presentation/BookingControllerTest.java
+++ b/src/test/java/com/goggles/mentoring_service/presentation/BookingControllerTest.java
@@ -44,7 +44,7 @@ class BookingControllerTest {
   void createBooking_success() throws Exception {
     UUID bookingId = UUID.randomUUID();
     given(bookingService.createBooking(any()))
-        .willReturn(BookingResult.Create.of(new MentoringBookingId(bookingId)));
+        .willReturn(new BookingResult.Create(bookingId, MENTORING_ID, TITLE, PRICE, MENTOR_ID, MENTOR_NAME));
 
     mockMvc
         .perform(
@@ -54,7 +54,7 @@ class BookingControllerTest {
                 .content(objectMapper.writeValueAsString(defaultRequest())))
         .andDo(print())
         .andExpect(status().isCreated())
-        .andExpect(jsonPath("$.bookingId").value(bookingId.toString()));
+        .andExpect(jsonPath("$.enrollmentId").value(bookingId.toString()));
   }
 
   @Test

--- a/src/test/java/com/goggles/mentoring_service/presentation/BookingControllerTest.java
+++ b/src/test/java/com/goggles/mentoring_service/presentation/BookingControllerTest.java
@@ -59,12 +59,16 @@ class BookingControllerTest {
 
   @Test
   void createBooking_fails_without_mentoringId() throws Exception {
+    String body =
+        """
+        {"bookingTimeSlots":[{"date":"2026-06-01","startTime":"10:00:00","endTime":"11:00:00"}]}
+        """;
     mockMvc
         .perform(
             post("/api/v1/mentoring-bookings")
                 .contentType(MediaType.APPLICATION_JSON)
                 .headers(TestHeaders.headersFor(UserType.STUDENT))
-                .content("{}"))
+                .content(body))
         .andExpect(status().isBadRequest());
   }
 

--- a/src/test/java/com/goggles/mentoring_service/presentation/MentoringCategoryControllerTest.java
+++ b/src/test/java/com/goggles/mentoring_service/presentation/MentoringCategoryControllerTest.java
@@ -1,9 +1,17 @@
 package com.goggles.mentoring_service.presentation;
 
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
 import com.goggles.mentoring_service.application.result.CategoryResult;
 import com.goggles.mentoring_service.application.service.CategoryService;
 import com.goggles.mentoring_service.infrastructure.config.WebMvcConfig;
 import com.goggles.mentoring_service.presentation.support.UserContextArgumentResolver;
+import java.util.List;
+import java.util.UUID;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
@@ -12,68 +20,53 @@ import org.springframework.data.jpa.mapping.JpaMetamodelMappingContext;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 
-import java.util.List;
-import java.util.UUID;
-
-import static org.mockito.BDDMockito.given;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
-
 @WebMvcTest(MentoringCategoryController.class)
 @Import({WebMvcConfig.class, UserContextArgumentResolver.class})
 @MockitoBean(types = JpaMetamodelMappingContext.class)
 class MentoringCategoryControllerTest {
 
-	@Autowired
-	private MockMvc mockMvc;
+  @Autowired private MockMvc mockMvc;
 
-	@MockitoBean
-	private CategoryService categoryService;
+  @MockitoBean private CategoryService categoryService;
 
-	@Test
-	void getActiveCategories_returns_200_with_category_list() throws Exception {
-		UUID id1 = UUID.randomUUID();
-		UUID id2 = UUID.randomUUID();
-		String name1 = UUID.randomUUID()
-				.toString();
-		String name2 = UUID.randomUUID()
-				.toString();
-		String code1 = UUID.randomUUID()
-				.toString()
-				.substring(0, 8)
-				.toUpperCase();
-		String code2 = UUID.randomUUID()
-				.toString()
-				.substring(0, 8)
-				.toUpperCase();
+  @Test
+  void getActiveCategories_success() throws Exception {
+    UUID id1 = UUID.randomUUID();
+    UUID id2 = UUID.randomUUID();
+    String name1 = UUID.randomUUID().toString();
+    String name2 = UUID.randomUUID().toString();
+    String code1 = UUID.randomUUID().toString().substring(0, 8).toUpperCase();
+    String code2 = UUID.randomUUID().toString().substring(0, 8).toUpperCase();
 
-		given(categoryService.getActiveCategories()).willReturn(
-				List.of(new CategoryResult.Info(id1, name1, code1, 0, true),
-						new CategoryResult.Info(id2, name2, code2, 1, true)));
+    given(categoryService.getActiveCategories())
+        .willReturn(
+            List.of(
+                new CategoryResult.Info(id1, name1, code1, 0, true),
+                new CategoryResult.Info(id2, name2, code2, 1, true)));
 
-		mockMvc.perform(get("/api/v1/mentorings-categories"))
-				.andDo(print())
-				.andExpect(status().isOk())
-				.andExpect(jsonPath("$.categories").isArray())
-				.andExpect(jsonPath("$.categories.length()").value(2))
-				.andExpect(jsonPath("$.categories[0].categoryId").value(id1.toString()))
-				.andExpect(jsonPath("$.categories[0].name").value(name1))
-				.andExpect(jsonPath("$.categories[0].code").value(code1))
-				.andExpect(jsonPath("$.categories[0].sortOrder").value(0))
-				.andExpect(jsonPath("$.categories[0].active").doesNotExist())
-				.andExpect(jsonPath("$.categories[1].name").value(name2));
-	}
+    mockMvc
+        .perform(get("/api/v1/mentorings-categories"))
+        .andDo(print())
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.categories").isArray())
+        .andExpect(jsonPath("$.categories.length()").value(2))
+        .andExpect(jsonPath("$.categories[0].categoryId").value(id1.toString()))
+        .andExpect(jsonPath("$.categories[0].name").value(name1))
+        .andExpect(jsonPath("$.categories[0].code").value(code1))
+        .andExpect(jsonPath("$.categories[0].sortOrder").value(0))
+        .andExpect(jsonPath("$.categories[0].active").doesNotExist())
+        .andExpect(jsonPath("$.categories[1].name").value(name2));
+  }
 
-	@Test
-	void getActiveCategories_returns_empty_list_when_no_active_categories() throws Exception {
-		given(categoryService.getActiveCategories()).willReturn(List.of());
+  @Test
+  void getActiveCategories_empty() throws Exception {
+    given(categoryService.getActiveCategories()).willReturn(List.of());
 
-		mockMvc.perform(get("/api/v1/mentorings-categories"))
-				.andDo(print())
-				.andExpect(status().isOk())
-				.andExpect(jsonPath("$.categories").isArray())
-				.andExpect(jsonPath("$.categories").isEmpty());
-	}
+    mockMvc
+        .perform(get("/api/v1/mentorings-categories"))
+        .andDo(print())
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.categories").isArray())
+        .andExpect(jsonPath("$.categories").isEmpty());
+  }
 }

--- a/src/test/java/com/goggles/mentoring_service/presentation/MentoringControllerTest.java
+++ b/src/test/java/com/goggles/mentoring_service/presentation/MentoringControllerTest.java
@@ -1,5 +1,14 @@
 package com.goggles.mentoring_service.presentation;
 
+import static com.goggles.mentoring_service.domain.mentoring.MentoringFixture.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.goggles.common.pagination.CommonPageRequestArgumentResolver;
 import com.goggles.mentoring_service.application.result.MentoringResult;
@@ -9,6 +18,9 @@ import com.goggles.mentoring_service.domain.mentoring.exception.MentoringNotFoun
 import com.goggles.mentoring_service.infrastructure.config.WebMvcConfig;
 import com.goggles.mentoring_service.presentation.dto.MentoringRequest;
 import com.goggles.mentoring_service.presentation.support.UserContextArgumentResolver;
+import java.time.DayOfWeek;
+import java.util.List;
+import java.util.UUID;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
@@ -25,202 +37,232 @@ import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.web.method.support.HandlerMethodArgumentResolver;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
-import java.time.DayOfWeek;
-import java.util.List;
-import java.util.UUID;
-
-import static com.goggles.mentoring_service.domain.mentoring.MentoringFixture.*;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.BDDMockito.given;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
-import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
-
 @WebMvcTest(MentoringController.class)
-@Import({WebMvcConfig.class, UserContextArgumentResolver.class,
-		MentoringControllerTest.PageResolverConfig.class})
+@Import({
+  WebMvcConfig.class,
+  UserContextArgumentResolver.class,
+  MentoringControllerTest.PageResolverConfig.class
+})
 @MockitoBean(types = JpaMetamodelMappingContext.class)
 class MentoringControllerTest {
 
-	@Autowired
-	private MockMvc mockMvc;
-	@Autowired
-	private ObjectMapper objectMapper;
-	@MockitoBean
-	private MentoringService mentoringService;
+  @TestConfiguration
+  static class PageResolverConfig implements WebMvcConfigurer {
+    @Override
+    public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
+      resolvers.add(new CommonPageRequestArgumentResolver());
+    }
+  }
 
-	@Test
-	void createMentoring_success() throws Exception {
-		UUID mentoringId = UUID.randomUUID();
-		given(mentoringService.createMentoring(any())).willReturn(mentoringId);
+  @Autowired private MockMvc mockMvc;
 
-		mockMvc.perform(post("/api/v1/mentorings").contentType(MediaType.APPLICATION_JSON)
-						.headers(userHeaders())
-						.content(objectMapper.writeValueAsString(defaultRequest())))
-				.andExpect(status().isCreated())
-				.andExpect(jsonPath("$.mentoringId").value(mentoringId.toString()));
-	}
+  @Autowired private ObjectMapper objectMapper;
 
-	@Test
-	void createMentoring_invalid_request() throws Exception {
-		mockMvc.perform(post("/api/v1/mentorings").contentType(MediaType.APPLICATION_JSON)
-						.headers(userHeaders())
-						.content("{}"))
-				.andExpect(status().isBadRequest());
-	}
+  @MockitoBean private MentoringService mentoringService;
 
-	@Test
-	void getMentoring_returns_200_with_detail() throws Exception {
-		UUID mentoringId = UUID.randomUUID();
-		MentoringResult.Detail detail =
-				new MentoringResult.Detail(mentoringId, TITLE, SUBTITLE, DESCRIPTION,
-						new MentoringResult.Detail.MentorInfo(MENTOR_NAME, MENTOR_FIELD),
-						new MentoringResult.Detail.CategoryInfo(CATEGORY_NAME, CATEGORY_CODE),
-						MentoringStatus.INACTIVE, Format.SINGLE, MentoringType.ONE_ON_ONE,
-						MentoringDuration.MINUTES_60, SESSION_COUNT, MAX_PARTICIPANTS, false, PRICE,
-						null);
-		given(mentoringService.getMentoring(mentoringId)).willReturn(detail);
+  @Test
+  void createMentoring_success() throws Exception {
+    UUID mentoringId = UUID.randomUUID();
+    given(mentoringService.createMentoring(any())).willReturn(mentoringId);
 
-		mockMvc.perform(get("/api/v1/mentorings/{mentoringId}", mentoringId))
-				.andDo(print())
-				.andExpect(status().isOk())
-				.andExpect(jsonPath("$.mentoringId").value(mentoringId.toString()))
-				.andExpect(jsonPath("$.title").value(TITLE))
-				.andExpect(jsonPath("$.subtitle").value(SUBTITLE))
-				.andExpect(jsonPath("$.status").value(MentoringStatus.INACTIVE.name()))
-				.andExpect(jsonPath("$.price").value(PRICE))
-				.andExpect(jsonPath("$.mentor.name").value(MENTOR_NAME))
-				.andExpect(jsonPath("$.mentor.field").value(MENTOR_FIELD))
-				.andExpect(jsonPath("$.category.name").value(CATEGORY_NAME))
-				.andExpect(jsonPath("$.category.code").value(CATEGORY_CODE));
-	}
+    mockMvc
+        .perform(
+            post("/api/v1/mentorings")
+                .contentType(MediaType.APPLICATION_JSON)
+                .headers(userHeaders())
+                .content(objectMapper.writeValueAsString(defaultRequest())))
+        .andExpect(status().isCreated())
+        .andExpect(jsonPath("$.mentoringId").value(mentoringId.toString()));
+  }
 
-	@Test
-	void getMentoring_returns_404_when_not_found() throws Exception {
-		UUID unknownId = UUID.randomUUID();
-		given(mentoringService.getMentoring(unknownId)).willThrow(
-				new MentoringNotFoundException(new MentoringId(unknownId)));
+  @Test
+  void createMentoring_invalid_request() throws Exception {
+    mockMvc
+        .perform(
+            post("/api/v1/mentorings")
+                .contentType(MediaType.APPLICATION_JSON)
+                .headers(userHeaders())
+                .content("{}"))
+        .andExpect(status().isBadRequest());
+  }
 
-		mockMvc.perform(get("/api/v1/mentorings/{mentoringId}", unknownId))
-				.andDo(print())
-				.andExpect(status().isNotFound())
-				.andExpect(jsonPath("$.title").value("Not Found"))
-				.andExpect(jsonPath("$.detail").value(
-						org.hamcrest.Matchers.containsString(unknownId.toString())));
-	}
+  @Test
+  void getMentoring_success() throws Exception {
+    UUID mentoringId = UUID.randomUUID();
+    MentoringResult.Detail detail =
+        new MentoringResult.Detail(
+            mentoringId,
+            TITLE,
+            SUBTITLE,
+            DESCRIPTION,
+            new MentoringResult.Detail.MentorInfo(MENTOR_NAME, MENTOR_FIELD),
+            new MentoringResult.Detail.CategoryInfo(CATEGORY_NAME, CATEGORY_CODE),
+            MentoringStatus.INACTIVE,
+            Format.SINGLE,
+            MentoringType.ONE_ON_ONE,
+            MentoringDuration.MINUTES_60,
+            SESSION_COUNT,
+            MAX_PARTICIPANTS,
+            false,
+            PRICE,
+            null);
+    given(mentoringService.getMentoring(mentoringId)).willReturn(detail);
 
-	@Test
-	void getMentoringSchedules_returns_200_with_schedules() throws Exception {
-		UUID mentoringId = UUID.randomUUID();
-		MentoringResult.Schedules schedules = new MentoringResult.Schedules(
-				List.of(new MentoringResult.Schedules.RepeatPatternDto(DayOfWeek.MONDAY, START_TIME,
-								END_TIME),
-						new MentoringResult.Schedules.RepeatPatternDto(DayOfWeek.WEDNESDAY,
-								START_TIME, END_TIME)),
-				List.of(new MentoringResult.Schedules.SessionDto(SESSION_DATE_1, START_TIME,
-								END_TIME, SessionStatus.AVAILABLE),
-						new MentoringResult.Schedules.SessionDto(SESSION_DATE_2, START_TIME,
-								END_TIME, SessionStatus.AVAILABLE)));
-		given(mentoringService.getMentoringSchedules(mentoringId)).willReturn(schedules);
+    mockMvc
+        .perform(get("/api/v1/mentorings/{mentoringId}", mentoringId))
+        .andDo(print())
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.mentoringId").value(mentoringId.toString()))
+        .andExpect(jsonPath("$.title").value(TITLE))
+        .andExpect(jsonPath("$.subtitle").value(SUBTITLE))
+        .andExpect(jsonPath("$.status").value(MentoringStatus.INACTIVE.name()))
+        .andExpect(jsonPath("$.price").value(PRICE))
+        .andExpect(jsonPath("$.mentor.name").value(MENTOR_NAME))
+        .andExpect(jsonPath("$.mentor.field").value(MENTOR_FIELD))
+        .andExpect(jsonPath("$.category.name").value(CATEGORY_NAME))
+        .andExpect(jsonPath("$.category.code").value(CATEGORY_CODE));
+  }
 
-		mockMvc.perform(get("/api/v1/mentorings/{mentoringId}/schedules", mentoringId))
-				.andDo(print())
-				.andExpect(status().isOk())
-				.andExpect(jsonPath("$.repeatPatterns").isArray())
-				.andExpect(jsonPath("$.repeatPatterns.length()").value(2))
-				.andExpect(jsonPath("$.repeatPatterns[0].dayOfWeek").value("MONDAY"))
-				.andExpect(jsonPath("$.repeatPatterns[1].dayOfWeek").value("WEDNESDAY"))
-				.andExpect(jsonPath("$.sessions").isArray())
-				.andExpect(jsonPath("$.sessions.length()").value(2))
-				.andExpect(jsonPath("$.sessions[0].date").value(SESSION_DATE_1.toString()))
-				.andExpect(jsonPath("$.sessions[0].status").value(SessionStatus.AVAILABLE.name()));
-	}
+  @Test
+  void getMentoring_not_found() throws Exception {
+    UUID unknownId = UUID.randomUUID();
+    given(mentoringService.getMentoring(unknownId))
+        .willThrow(new MentoringNotFoundException(new MentoringId(unknownId)));
 
-	@Test
-	void getMentoringSchedules_returns_404_when_not_found() throws Exception {
-		UUID unknownId = UUID.randomUUID();
-		given(mentoringService.getMentoringSchedules(unknownId)).willThrow(
-				new MentoringNotFoundException(new MentoringId(unknownId)));
+    mockMvc
+        .perform(get("/api/v1/mentorings/{mentoringId}", unknownId))
+        .andDo(print())
+        .andExpect(status().isNotFound())
+        .andExpect(jsonPath("$.title").value("Not Found"))
+        .andExpect(
+            jsonPath("$.detail").value(org.hamcrest.Matchers.containsString(unknownId.toString())));
+  }
 
-		mockMvc.perform(get("/api/v1/mentorings/{mentoringId}/schedules", unknownId))
-				.andDo(print())
-				.andExpect(status().isNotFound());
-	}
+  @Test
+  void getMentoringSchedules_success() throws Exception {
+    UUID mentoringId = UUID.randomUUID();
+    MentoringResult.Schedules schedules =
+        new MentoringResult.Schedules(
+            List.of(
+                new MentoringResult.Schedules.RepeatPatternDto(
+                    DayOfWeek.MONDAY, START_TIME, END_TIME),
+                new MentoringResult.Schedules.RepeatPatternDto(
+                    DayOfWeek.WEDNESDAY, START_TIME, END_TIME)),
+            List.of(
+                new MentoringResult.Schedules.SessionDto(
+                    SESSION_DATE_1, START_TIME, END_TIME, SessionStatus.AVAILABLE),
+                new MentoringResult.Schedules.SessionDto(
+                    SESSION_DATE_2, START_TIME, END_TIME, SessionStatus.AVAILABLE)));
+    given(mentoringService.getMentoringSchedules(mentoringId)).willReturn(schedules);
 
-	@Test
-	void searchMentorings_returns_200_with_page() throws Exception {
-		UUID mentoringId = UUID.randomUUID();
-		MentoringResult.Summary summary =
-				new MentoringResult.Summary(mentoringId, TITLE, SUBTITLE, MENTOR_NAME,
-						CATEGORY_NAME, MentoringType.ONE_ON_ONE, Format.SINGLE, PRICE,
-						MentoringStatus.INACTIVE);
-		Page<MentoringResult.Summary> page =
-				new PageImpl<>(List.of(summary), PageRequest.of(0, 10), 1);
-		given(mentoringService.searchMentorings(any(), any())).willReturn(page);
+    mockMvc
+        .perform(get("/api/v1/mentorings/{mentoringId}/schedules", mentoringId))
+        .andDo(print())
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.repeatPatterns").isArray())
+        .andExpect(jsonPath("$.repeatPatterns.length()").value(2))
+        .andExpect(jsonPath("$.repeatPatterns[0].dayOfWeek").value("MONDAY"))
+        .andExpect(jsonPath("$.repeatPatterns[1].dayOfWeek").value("WEDNESDAY"))
+        .andExpect(jsonPath("$.sessions").isArray())
+        .andExpect(jsonPath("$.sessions.length()").value(2))
+        .andExpect(jsonPath("$.sessions[0].date").value(SESSION_DATE_1.toString()))
+        .andExpect(jsonPath("$.sessions[0].status").value(SessionStatus.AVAILABLE.name()));
+  }
 
-		mockMvc.perform(get("/api/v1/mentorings").param("page", "0")
-						.param("size", "10"))
-				.andDo(print())
-				.andExpect(status().isOk())
-				.andExpect(jsonPath("$.content").isArray())
-				.andExpect(jsonPath("$.content.length()").value(1))
-				.andExpect(jsonPath("$.content[0].mentoringId").value(mentoringId.toString()))
-				.andExpect(jsonPath("$.content[0].title").value(TITLE))
-				.andExpect(jsonPath("$.content[0].mentorName").value(MENTOR_NAME))
-				.andExpect(jsonPath("$.content[0].price").value(PRICE))
-				.andExpect(jsonPath("$.totalElements").value(1))
-				.andExpect(jsonPath("$.totalPages").value(1))
-				.andExpect(jsonPath("$.first").value(true))
-				.andExpect(jsonPath("$.last").value(true));
-	}
+  @Test
+  void getMentoringSchedules_not_found() throws Exception {
+    UUID unknownId = UUID.randomUUID();
+    given(mentoringService.getMentoringSchedules(unknownId))
+        .willThrow(new MentoringNotFoundException(new MentoringId(unknownId)));
 
-	@Test
-	void searchMentorings_with_all_filters_returns_200() throws Exception {
-		Page<MentoringResult.Summary> emptyPage =
-				new PageImpl<>(List.of(), PageRequest.of(0, 10), 0);
-		given(mentoringService.searchMentorings(any(), any())).willReturn(emptyPage);
+    mockMvc
+        .perform(get("/api/v1/mentorings/{mentoringId}/schedules", unknownId))
+        .andDo(print())
+        .andExpect(status().isNotFound());
+  }
 
-		mockMvc.perform(get("/api/v1/mentorings").param("keyword", "스프링")
-						.param("categoryId", CATEGORY_ID.toString())
-						.param("mentorId", MENTOR_ID.toString())
-						.param("status", MentoringStatus.INACTIVE.name())
-						.param("mentoringType", MentoringType.ONE_ON_ONE.name())
-						.param("sortBy", MentoringSort.PRICE_ASC.name())
-						.param("page", "0")
-						.param("size", "10"))
-				.andDo(print())
-				.andExpect(status().isOk())
-				.andExpect(jsonPath("$.content").isArray())
-				.andExpect(jsonPath("$.totalElements").value(0));
-	}
+  @Test
+  void searchMentorings_success() throws Exception {
+    UUID mentoringId = UUID.randomUUID();
+    MentoringResult.Summary summary =
+        new MentoringResult.Summary(
+            mentoringId,
+            TITLE,
+            SUBTITLE,
+            MENTOR_NAME,
+            CATEGORY_NAME,
+            MentoringType.ONE_ON_ONE,
+            Format.SINGLE,
+            PRICE,
+            MentoringStatus.INACTIVE);
+    Page<MentoringResult.Summary> page = new PageImpl<>(List.of(summary), PageRequest.of(0, 10), 1);
+    given(mentoringService.searchMentorings(any(), any())).willReturn(page);
 
-	private HttpHeaders userHeaders() {
-		HttpHeaders headers = new HttpHeaders();
-		headers.add("X-User-Id", MENTOR_ID.toString());
-		headers.add("X-User-Type", MENTOR_TYPE.name());
-		headers.add("X-User-Name", MENTOR_NAME);
-		headers.add("X-User-Email", MENTOR_EMAIL);
-		headers.add("X-User-Field", MENTOR_FIELD);
-		return headers;
-	}
+    mockMvc
+        .perform(get("/api/v1/mentorings").param("page", "0").param("size", "10"))
+        .andDo(print())
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.content").isArray())
+        .andExpect(jsonPath("$.content.length()").value(1))
+        .andExpect(jsonPath("$.content[0].mentoringId").value(mentoringId.toString()))
+        .andExpect(jsonPath("$.content[0].title").value(TITLE))
+        .andExpect(jsonPath("$.content[0].mentorName").value(MENTOR_NAME))
+        .andExpect(jsonPath("$.content[0].price").value(PRICE))
+        .andExpect(jsonPath("$.totalElements").value(1))
+        .andExpect(jsonPath("$.totalPages").value(1))
+        .andExpect(jsonPath("$.first").value(true))
+        .andExpect(jsonPath("$.last").value(true));
+  }
 
-	private MentoringRequest.Create defaultRequest() {
-		return new MentoringRequest.Create(CATEGORY_ID, TITLE, SUBTITLE, DESCRIPTION, DURATION,
-				MentoringType.ONE_ON_ONE, Format.SINGLE, SESSION_COUNT, MAX_PARTICIPANTS, false,
-				PRICE, null,
-				List.of(new MentoringRequest.Create.SessionDto(SESSION_DATE_1, START_TIME,
-						END_TIME)),
-				List.of(new MentoringRequest.Create.RepeatPatternDto(java.time.DayOfWeek.MONDAY,
-						START_TIME, END_TIME)));
-	}
+  @Test
+  void searchMentorings_with_all_filters() throws Exception {
+    Page<MentoringResult.Summary> emptyPage = new PageImpl<>(List.of(), PageRequest.of(0, 10), 0);
+    given(mentoringService.searchMentorings(any(), any())).willReturn(emptyPage);
 
-	@TestConfiguration
-	static class PageResolverConfig implements WebMvcConfigurer {
-		@Override
-		public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
-			resolvers.add(new CommonPageRequestArgumentResolver());
-		}
-	}
+    mockMvc
+        .perform(
+            get("/api/v1/mentorings")
+                .param("keyword", "스프링")
+                .param("categoryId", CATEGORY_ID.toString())
+                .param("mentorId", MENTOR_ID.toString())
+                .param("status", MentoringStatus.INACTIVE.name())
+                .param("mentoringType", MentoringType.ONE_ON_ONE.name())
+                .param("sortBy", MentoringSort.PRICE_ASC.name())
+                .param("page", "0")
+                .param("size", "10"))
+        .andDo(print())
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.content").isArray())
+        .andExpect(jsonPath("$.totalElements").value(0));
+  }
+
+  private HttpHeaders userHeaders() {
+    HttpHeaders headers = new HttpHeaders();
+    headers.add("X-User-Id", MENTOR_ID.toString());
+    headers.add("X-User-Type", MENTOR_TYPE.name());
+    headers.add("X-User-Name", MENTOR_NAME);
+    headers.add("X-User-Email", MENTOR_EMAIL);
+    headers.add("X-User-Field", MENTOR_FIELD);
+    return headers;
+  }
+
+  private MentoringRequest.Create defaultRequest() {
+    return new MentoringRequest.Create(
+        CATEGORY_ID,
+        TITLE,
+        SUBTITLE,
+        DESCRIPTION,
+        DURATION,
+        MentoringType.ONE_ON_ONE,
+        Format.SINGLE,
+        SESSION_COUNT,
+        MAX_PARTICIPANTS,
+        false,
+        PRICE,
+        null,
+        List.of(new MentoringRequest.Create.SessionDto(SESSION_DATE_1, START_TIME, END_TIME)),
+        List.of(
+            new MentoringRequest.Create.RepeatPatternDto(
+                java.time.DayOfWeek.MONDAY, START_TIME, END_TIME)));
+  }
 }


### PR DESCRIPTION
### 📌 관련 이슈
- close #20 

### 💡 작업 내용
  - 멘토링 예약 생성 API 구현                                         
  -  예약 생성, 결제 완료/실패, 수락, 거절, 취소 상태 전이
  - BookedMentoring 스냅샷 패턴 적용                       
  - BookingStatus 상태 유효하지 않은 전이 시 명확한 예외 반환                                               
  - SessionSlot을 application.command → domain.booking으로 이동                                                         
  - Mentoring.bookSession() 추가 — 예약 시 해당 세션을 BOOKED 상태로 변경                                               
  - 취소 24시간 데드라인 검증 도메인 레이어에서 처리                                                                    
  - 도메인 단위 테스트, 서비스 단위/통합 테스트, 컨트롤러 테스트 작성 

### 🔍 변경 이유
  - 멘티가 원하는 세션 슬롯을 선택해 멘토링을 예약할 수 있도록 기능 추가                                                
  - 예약 후 멘토링 정보가 변경되어도 예약 기록이 깨지지 않도록 스냅샷 패턴 적용

### 📝 리뷰 포인트 (선택)
- BookingStatus.canTransitionTo() — 상태 전이 허용 범위가 비즈니스 요건과 맞는지

### 🧠 기타 참고 사항
BookingStatus 전이 흐름: PENDING → PAYMENT_COMPLETED / PAYMENT_FAILED / CANCELED → ACCEPTED / REJECTED / CANCELED   )

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# 릴리스 노트

* **새 기능**
  * 멘토링 세션 예약 기능 추가: 사용자가 원하는 시간에 멘토링 세션을 예약할 수 있습니다.
  * 다중 세션 예약 지원: 한 번의 예약으로 여러 개의 세션을 동시에 선택하여 예약할 수 있습니다.
  * 결제 실패 처리: 예약 결제 실패 시 시스템이 자동으로 상태를 관리합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->