### PR TITLE
[FEAT] 멘토링 예약 상태변경

### DIFF
--- a/src/main/java/com/goggles/mentoring_service/MentoringServerApplication.java
+++ b/src/main/java/com/goggles/mentoring_service/MentoringServerApplication.java
@@ -2,10 +2,12 @@ package com.goggles.mentoring_service;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.autoconfigure.domain.EntityScan;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @EnableJpaAuditing
 @SpringBootApplication
+@EntityScan(basePackages = {"com.goggles.mentoring_service", "com.goggles.common.domain"})
 public class MentoringServerApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/com/goggles/mentoring_service/application/command/BookingCommand.java
+++ b/src/main/java/com/goggles/mentoring_service/application/command/BookingCommand.java
@@ -1,5 +1,6 @@
 package com.goggles.mentoring_service.application.command;
 
+import com.goggles.mentoring_service.domain._common.UserType;
 import com.goggles.mentoring_service.domain.booking.MentoringBookingId;
 import com.goggles.mentoring_service.domain.booking.SessionSlot;
 import java.util.List;
@@ -16,4 +17,6 @@ public class BookingCommand {
   public record PaymentFailed(
           MentoringBookingId mentoringBookingId, UUID orderId, String failureReason
   ) {}
+
+  public record Accept(UUID bookingId, UUID userId, UserType userType) {}
 }

--- a/src/main/java/com/goggles/mentoring_service/application/command/BookingCommand.java
+++ b/src/main/java/com/goggles/mentoring_service/application/command/BookingCommand.java
@@ -19,4 +19,6 @@ public class BookingCommand {
   ) {}
 
   public record Accept(UUID bookingId, UUID userId, UserType userType) {}
+
+  public record Reject(UUID bookingId, UUID userId, UserType userType, String reason) {}
 }

--- a/src/main/java/com/goggles/mentoring_service/application/command/BookingCommand.java
+++ b/src/main/java/com/goggles/mentoring_service/application/command/BookingCommand.java
@@ -21,4 +21,6 @@ public class BookingCommand {
   public record Accept(UUID bookingId, UUID userId, UserType userType) {}
 
   public record Reject(UUID bookingId, UUID userId, UserType userType, String reason) {}
+
+  public record Cancel(UUID bookingId, UUID userId, UserType userType, String reason) {}
 }

--- a/src/main/java/com/goggles/mentoring_service/application/service/BookingService.java
+++ b/src/main/java/com/goggles/mentoring_service/application/service/BookingService.java
@@ -116,4 +116,26 @@ public class BookingService {
             firstSession.getSessionStartTime(),
             firstSession.getSessionEndTime()));
   }
+
+  @Transactional
+  public void rejectBooking(BookingCommand.Reject command) {
+    MentoringBookingId id = new MentoringBookingId(command.bookingId());
+    MentoringBooking booking =
+        bookingRepository.findById(id).orElseThrow(() -> new BookingNotFoundException(id));
+    booking.reject(command.userId(), command.userType(), command.reason(), LocalDateTime.now());
+
+    BookedTime firstSession = booking.getBookedTimes().getFirst();
+    events.trigger(
+        command.bookingId() + "." + TOPIC_REJECTED,
+        DOMAIN_TYPE,
+        TOPIC_REJECTED,
+        new BookingRejectedEvent(
+            booking.getMentoringBookingId().bookingId(),
+            booking.getMentee().getId(),
+            booking.getBookedMentoring().getMentorId(),
+            booking.getBookedMentoring().getMentorName(),
+            booking.getBookedMentoring().getTitle(),
+            command.reason(),
+            firstSession.getSessionDate()));
+  }
 }

--- a/src/main/java/com/goggles/mentoring_service/application/service/BookingService.java
+++ b/src/main/java/com/goggles/mentoring_service/application/service/BookingService.java
@@ -1,5 +1,6 @@
 package com.goggles.mentoring_service.application.service;
 
+import com.goggles.common.event.Events;
 import com.goggles.common.exception.ForbiddenException;
 import com.goggles.common.pagination.CommonPageRequest;
 import com.goggles.mentoring_service.application.command.BookingCommand;
@@ -8,10 +9,15 @@ import com.goggles.mentoring_service.domain.booking.BookingSearchCondition;
 import com.goggles.mentoring_service.application.result.BookingResult;
 import com.goggles.mentoring_service.domain._common.UserType;
 import com.goggles.mentoring_service.domain.booking.BookedMentoring;
+import com.goggles.mentoring_service.domain.booking.BookedMentoring;
+import com.goggles.mentoring_service.domain.booking.BookedTime;
 import com.goggles.mentoring_service.domain.booking.Mentee;
 import com.goggles.mentoring_service.domain.booking.MentoringBooking;
 import com.goggles.mentoring_service.domain.booking.MentoringBookingId;
 import com.goggles.mentoring_service.domain.booking.SessionSlot;
+import com.goggles.mentoring_service.domain.booking.event.BookingAcceptedEvent;
+import com.goggles.mentoring_service.domain.booking.event.BookingCanceledEvent;
+import com.goggles.mentoring_service.domain.booking.event.BookingRejectedEvent;
 import com.goggles.mentoring_service.domain.booking.exception.BookingNotFoundException;
 import com.goggles.mentoring_service.domain.booking.repository.MentoringBookingRepository;
 import com.goggles.mentoring_service.domain.mentoring.Mentoring;
@@ -32,9 +38,14 @@ import org.springframework.transaction.annotation.Transactional;
 @Service
 @RequiredArgsConstructor
 public class BookingService {
+  private static final String DOMAIN_TYPE = "BOOKING";
+  private static final String TOPIC_ACCEPTED = "booking.accepted";
+  private static final String TOPIC_REJECTED = "booking.rejected";
+  private static final String TOPIC_CANCELED = "booking.canceled";
 
   private final MentoringBookingRepository bookingRepository;
   private final MentoringRepository mentoringRepository;
+  private final Events events;
 
   @Transactional
   public BookingResult.Create createBooking(BookingCommand.Create command) {
@@ -134,6 +145,28 @@ public class BookingService {
             booking.getMentee().getId(),
             booking.getBookedMentoring().getMentorId(),
             booking.getBookedMentoring().getMentorName(),
+            booking.getBookedMentoring().getTitle(),
+            command.reason(),
+            firstSession.getSessionDate()));
+  }
+
+  @Transactional
+  public void cancelBooking(BookingCommand.Cancel command) {
+    MentoringBookingId id = new MentoringBookingId(command.bookingId());
+    MentoringBooking booking =
+        bookingRepository.findById(id).orElseThrow(() -> new BookingNotFoundException(id));
+    booking.cancel(command.userId(), command.userType(), command.reason(), LocalDateTime.now());
+
+    BookedTime firstSession = booking.getBookedTimes().getFirst();
+    events.trigger(
+        command.bookingId() + "." + TOPIC_CANCELED,
+        DOMAIN_TYPE,
+        TOPIC_CANCELED,
+        new BookingCanceledEvent(
+            booking.getMentoringBookingId().bookingId(),
+            command.userId(),
+            booking.getMentee().getId(),
+            booking.getBookedMentoring().getMentorId(),
             booking.getBookedMentoring().getTitle(),
             command.reason(),
             firstSession.getSessionDate()));

--- a/src/main/java/com/goggles/mentoring_service/application/service/BookingService.java
+++ b/src/main/java/com/goggles/mentoring_service/application/service/BookingService.java
@@ -5,13 +5,9 @@ import com.goggles.common.exception.ForbiddenException;
 import com.goggles.common.pagination.CommonPageRequest;
 import com.goggles.mentoring_service.application.command.BookingCommand;
 import com.goggles.mentoring_service.application.command.MenteeInfo;
+import com.goggles.mentoring_service.domain._common.UserType;
 import com.goggles.mentoring_service.domain.booking.BookingSearchCondition;
 import com.goggles.mentoring_service.application.result.BookingResult;
-import com.goggles.mentoring_service.domain._common.UserType;
-import com.goggles.mentoring_service.domain.booking.BookedMentoring;
-import com.goggles.mentoring_service.domain.booking.BookedMentoring;
-import com.goggles.mentoring_service.domain.booking.BookedTime;
-import com.goggles.mentoring_service.domain.booking.Mentee;
 import com.goggles.mentoring_service.domain.booking.MentoringBooking;
 import com.goggles.mentoring_service.domain.booking.MentoringBookingId;
 import com.goggles.mentoring_service.domain.booking.SessionSlot;
@@ -25,7 +21,6 @@ import com.goggles.mentoring_service.domain.mentoring.MentoringId;
 import com.goggles.mentoring_service.domain.mentoring.exception.MentoringNotFoundException;
 import com.goggles.mentoring_service.domain.mentoring.repository.MentoringRepository;
 
-import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.UUID;
@@ -87,10 +82,8 @@ public class BookingService {
   }
 
   private void checkAccess(MentoringBooking booking, UUID userId, UserType userType) {
-    boolean isMentee = userType == UserType.STUDENT && booking.getMentee()
-            .isMentee(userId);
-    boolean isMentor = userType == UserType.INSTRUCTOR && booking.getBookedMentoring()
-            .isMentor(userId);
+    boolean isMentee = userType == UserType.STUDENT && booking.getMentee().isMentee(userId);
+    boolean isMentor = userType == UserType.INSTRUCTOR && booking.getBookedMentoring().isMentor(userId);
     if (!isMentee && !isMentor) {
       throw new ForbiddenException("해당 예약에 접근 권한이 없습니다.");
     }
@@ -99,8 +92,8 @@ public class BookingService {
   @Transactional
   public void paymentFailed(BookingCommand.PaymentFailed command) {
     MentoringBooking booking =
-            bookingRepository.findById(command.mentoringBookingId())
-                    .orElseThrow(() -> new BookingNotFoundException(command.mentoringBookingId()));
+        bookingRepository.findById(command.mentoringBookingId())
+            .orElseThrow(() -> new BookingNotFoundException(command.mentoringBookingId()));
     booking.failPayment(command.failureReason(), LocalDateTime.now());
     bookingRepository.save(booking);
   }
@@ -112,7 +105,6 @@ public class BookingService {
         bookingRepository.findById(id).orElseThrow(() -> new BookingNotFoundException(id));
     booking.accept(command.userId(), command.userType());
 
-    BookedTime firstSession = booking.getBookedTimes().getFirst();
     events.trigger(
         command.bookingId() + "." + TOPIC_ACCEPTED,
         DOMAIN_TYPE,
@@ -123,9 +115,7 @@ public class BookingService {
             booking.getBookedMentoring().getMentorId(),
             booking.getBookedMentoring().getMentorName(),
             booking.getBookedMentoring().getTitle(),
-            firstSession.getSessionDate(),
-            firstSession.getSessionStartTime(),
-            firstSession.getSessionEndTime()));
+            booking.getBookedTimes()));
   }
 
   @Transactional
@@ -135,18 +125,19 @@ public class BookingService {
         bookingRepository.findById(id).orElseThrow(() -> new BookingNotFoundException(id));
     booking.reject(command.userId(), command.userType(), command.reason(), LocalDateTime.now());
 
-    BookedTime firstSession = booking.getBookedTimes().getFirst();
     events.trigger(
         command.bookingId() + "." + TOPIC_REJECTED,
         DOMAIN_TYPE,
         TOPIC_REJECTED,
-        new BookingRejectedEvent(booking.getMentoringBookingId().bookingId(),
+        new BookingRejectedEvent(
+            booking.getMentoringBookingId().bookingId(),
             booking.getMentee().getId(),
             booking.getBookedMentoring().getMentorId(),
             booking.getBookedMentoring().getMentorName(),
             booking.getBookedMentoring().getTitle(),
             command.reason(),
-            firstSession.getSessionDate(), booking.getOrderId()));
+            booking.getBookedTimes(),
+            booking.getOrderId()));
   }
 
   @Transactional
@@ -156,7 +147,6 @@ public class BookingService {
         bookingRepository.findById(id).orElseThrow(() -> new BookingNotFoundException(id));
     booking.cancel(command.userId(), command.userType(), command.reason(), LocalDateTime.now());
 
-    BookedTime firstSession = booking.getBookedTimes().getFirst();
     events.trigger(
         command.bookingId() + "." + TOPIC_CANCELED,
         DOMAIN_TYPE,
@@ -168,6 +158,7 @@ public class BookingService {
             booking.getBookedMentoring().getMentorId(),
             booking.getBookedMentoring().getTitle(),
             command.reason(),
-            firstSession.getSessionDate(), booking.getOrderId()));
+            booking.getBookedTimes(),
+            booking.getOrderId()));
   }
 }

--- a/src/main/java/com/goggles/mentoring_service/application/service/BookingService.java
+++ b/src/main/java/com/goggles/mentoring_service/application/service/BookingService.java
@@ -140,14 +140,13 @@ public class BookingService {
         command.bookingId() + "." + TOPIC_REJECTED,
         DOMAIN_TYPE,
         TOPIC_REJECTED,
-        new BookingRejectedEvent(
-            booking.getMentoringBookingId().bookingId(),
+        new BookingRejectedEvent(booking.getMentoringBookingId().bookingId(),
             booking.getMentee().getId(),
             booking.getBookedMentoring().getMentorId(),
             booking.getBookedMentoring().getMentorName(),
             booking.getBookedMentoring().getTitle(),
             command.reason(),
-            firstSession.getSessionDate()));
+            firstSession.getSessionDate(), booking.getOrderId()));
   }
 
   @Transactional
@@ -169,6 +168,6 @@ public class BookingService {
             booking.getBookedMentoring().getMentorId(),
             booking.getBookedMentoring().getTitle(),
             command.reason(),
-            firstSession.getSessionDate()));
+            firstSession.getSessionDate(), booking.getOrderId()));
   }
 }

--- a/src/main/java/com/goggles/mentoring_service/application/service/BookingService.java
+++ b/src/main/java/com/goggles/mentoring_service/application/service/BookingService.java
@@ -93,4 +93,27 @@ public class BookingService {
     booking.failPayment(command.failureReason(), LocalDateTime.now());
     bookingRepository.save(booking);
   }
+
+  @Transactional
+  public void acceptBooking(BookingCommand.Accept command) {
+    MentoringBookingId id = new MentoringBookingId(command.bookingId());
+    MentoringBooking booking =
+        bookingRepository.findById(id).orElseThrow(() -> new BookingNotFoundException(id));
+    booking.accept(command.userId(), command.userType());
+
+    BookedTime firstSession = booking.getBookedTimes().getFirst();
+    events.trigger(
+        command.bookingId() + "." + TOPIC_ACCEPTED,
+        DOMAIN_TYPE,
+        TOPIC_ACCEPTED,
+        new BookingAcceptedEvent(
+            booking.getMentoringBookingId().bookingId(),
+            booking.getMentee().getId(),
+            booking.getBookedMentoring().getMentorId(),
+            booking.getBookedMentoring().getMentorName(),
+            booking.getBookedMentoring().getTitle(),
+            firstSession.getSessionDate(),
+            firstSession.getSessionStartTime(),
+            firstSession.getSessionEndTime()));
+  }
 }

--- a/src/main/java/com/goggles/mentoring_service/domain/booking/event/BookingAcceptedEvent.java
+++ b/src/main/java/com/goggles/mentoring_service/domain/booking/event/BookingAcceptedEvent.java
@@ -1,9 +1,9 @@
 package com.goggles.mentoring_service.domain.booking.event;
 
-import java.time.LocalDate;
-import java.time.LocalTime;
+import com.goggles.mentoring_service.domain.booking.BookedTime;
+
+import java.util.List;
 import java.util.UUID;
 
 public record BookingAcceptedEvent(UUID bookingId, UUID menteeId, UUID mentorId, String mentorName,
-								   String title, LocalDate sessionDate, LocalTime sessionStartTime,
-								   LocalTime sessionEndTime) {}
+								   String title, List<BookedTime> sessionSlots) {}

--- a/src/main/java/com/goggles/mentoring_service/domain/booking/event/BookingCanceledEvent.java
+++ b/src/main/java/com/goggles/mentoring_service/domain/booking/event/BookingCanceledEvent.java
@@ -4,4 +4,5 @@ import java.time.LocalDate;
 import java.util.UUID;
 
 public record BookingCanceledEvent(UUID bookingId, UUID canceledBy, UUID menteeId, UUID mentorId,
-								   String title, String reason, LocalDate sessionDate) {}
+								   String title, String reason, LocalDate sessionDate,
+								   UUID orderId) {}

--- a/src/main/java/com/goggles/mentoring_service/domain/booking/event/BookingCanceledEvent.java
+++ b/src/main/java/com/goggles/mentoring_service/domain/booking/event/BookingCanceledEvent.java
@@ -1,8 +1,10 @@
 package com.goggles.mentoring_service.domain.booking.event;
 
-import java.time.LocalDate;
+import com.goggles.mentoring_service.domain.booking.BookedTime;
+
+import java.util.List;
 import java.util.UUID;
 
 public record BookingCanceledEvent(UUID bookingId, UUID canceledBy, UUID menteeId, UUID mentorId,
-								   String title, String reason, LocalDate sessionDate,
+								   String title, String reason, List<BookedTime> sessionSlots,
 								   UUID orderId) {}

--- a/src/main/java/com/goggles/mentoring_service/domain/booking/event/BookingRejectedEvent.java
+++ b/src/main/java/com/goggles/mentoring_service/domain/booking/event/BookingRejectedEvent.java
@@ -4,4 +4,5 @@ import java.time.LocalDate;
 import java.util.UUID;
 
 public record BookingRejectedEvent(UUID bookingId, UUID menteeId, UUID mentorId, String mentorName,
-								   String title, String reason, LocalDate sessionDate) {}
+								   String title, String reason, LocalDate sessionDate,
+								   UUID orderId) {}

--- a/src/main/java/com/goggles/mentoring_service/domain/booking/event/BookingRejectedEvent.java
+++ b/src/main/java/com/goggles/mentoring_service/domain/booking/event/BookingRejectedEvent.java
@@ -1,8 +1,10 @@
 package com.goggles.mentoring_service.domain.booking.event;
 
-import java.time.LocalDate;
+import com.goggles.mentoring_service.domain.booking.BookedTime;
+
+import java.util.List;
 import java.util.UUID;
 
 public record BookingRejectedEvent(UUID bookingId, UUID menteeId, UUID mentorId, String mentorName,
-								   String title, String reason, LocalDate sessionDate,
+								   String title, String reason, List<BookedTime> sessionSlots,
 								   UUID orderId) {}

--- a/src/main/java/com/goggles/mentoring_service/domain/booking/event/BookingRequestedEvent.java
+++ b/src/main/java/com/goggles/mentoring_service/domain/booking/event/BookingRequestedEvent.java
@@ -4,7 +4,6 @@ import java.time.LocalDate;
 import java.time.LocalTime;
 import java.util.UUID;
 
-// TODO: 주문 서비스와 페이로드 협의 후 확정
 public record BookingRequestedEvent(UUID bookingId, UUID mentoringId, UUID menteeId, UUID mentorId,
 									String title, LocalDate sessionDate, LocalTime sessionStartTime,
 									LocalTime sessionEndTime) {}

--- a/src/main/java/com/goggles/mentoring_service/infrastructure/config/EventInfraConfig.java
+++ b/src/main/java/com/goggles/mentoring_service/infrastructure/config/EventInfraConfig.java
@@ -1,0 +1,51 @@
+package com.goggles.mentoring_service.infrastructure.config;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.goggles.common.domain.OutboxRepository;
+import com.goggles.common.event.Events;
+import com.goggles.common.event.OutboxEventListener;
+import com.goggles.common.event.OutboxStatusUpdater;
+import com.goggles.common.event.scheduler.OutboxRelayScheduler;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.scheduling.annotation.EnableScheduling;
+
+@Configuration
+@EnableScheduling
+public class EventInfraConfig {
+
+  @Bean
+  public Events events(ApplicationEventPublisher eventPublisher) {
+    return new Events(eventPublisher);
+  }
+
+  @Bean
+  @ConditionalOnBean(KafkaTemplate.class)
+  public OutboxStatusUpdater outboxStatusUpdater(
+      OutboxRepository outboxRepository, KafkaTemplate<String, Object> kafkaTemplate) {
+    return new OutboxStatusUpdater(outboxRepository, kafkaTemplate);
+  }
+
+  @Bean
+  @ConditionalOnBean(KafkaTemplate.class)
+  public OutboxEventListener outboxEventListener(
+      OutboxRepository outboxRepository,
+      KafkaTemplate<String, Object> kafkaTemplate,
+      ObjectMapper objectMapper,
+      OutboxStatusUpdater outboxStatusUpdater) {
+    return new OutboxEventListener(
+        outboxRepository, kafkaTemplate, objectMapper, outboxStatusUpdater);
+  }
+
+  @Bean
+  @ConditionalOnBean(KafkaTemplate.class)
+  public OutboxRelayScheduler outboxRelayScheduler(
+      OutboxRepository outboxRepository,
+      KafkaTemplate<String, Object> kafkaTemplate,
+      OutboxStatusUpdater outboxStatusUpdater) {
+    return new OutboxRelayScheduler(outboxRepository, kafkaTemplate, outboxStatusUpdater);
+  }
+}

--- a/src/main/java/com/goggles/mentoring_service/infrastructure/persistence/jpa/OutboxJpaRepository.java
+++ b/src/main/java/com/goggles/mentoring_service/infrastructure/persistence/jpa/OutboxJpaRepository.java
@@ -1,0 +1,7 @@
+package com.goggles.mentoring_service.infrastructure.persistence.jpa;
+
+import com.goggles.common.domain.OutboxRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface OutboxJpaRepository extends OutboxRepository {}

--- a/src/main/java/com/goggles/mentoring_service/presentation/BookingController.java
+++ b/src/main/java/com/goggles/mentoring_service/presentation/BookingController.java
@@ -53,3 +53,12 @@ public class BookingController {
     return CommonPageResponse.of(page.map(BookingResponse.Summary::of));
   }
 }
+
+  @ResponseStatus(HttpStatus.OK)
+  @PostMapping("/{bookingId}/acceptance")
+  public void acceptBooking(UserContext userContext, @PathVariable UUID bookingId) {
+    BookingCommand.Accept command =
+        new BookingCommand.Accept(bookingId, userContext.userId(), userContext.userType());
+    bookingService.acceptBooking(command);
+  }
+}

--- a/src/main/java/com/goggles/mentoring_service/presentation/BookingController.java
+++ b/src/main/java/com/goggles/mentoring_service/presentation/BookingController.java
@@ -52,7 +52,6 @@ public class BookingController {
     Page<BookingResult.Summary> page = bookingService.getMyBookings(condition, pageRequest);
     return CommonPageResponse.of(page.map(BookingResponse.Summary::of));
   }
-}
 
   @ResponseStatus(HttpStatus.OK)
   @PostMapping("/{bookingId}/acceptance")

--- a/src/main/java/com/goggles/mentoring_service/presentation/BookingController.java
+++ b/src/main/java/com/goggles/mentoring_service/presentation/BookingController.java
@@ -71,4 +71,14 @@ public class BookingController {
     BookingCommand.Reject command = request.toCommand(bookingId, userContext);
     bookingService.rejectBooking(command);
   }
+
+  @ResponseStatus(HttpStatus.OK)
+  @PostMapping("/{bookingId}/cancellation")
+  public void cancelBooking(
+      UserContext userContext,
+      @PathVariable UUID bookingId,
+      @Valid @RequestBody BookingRequest.Cancel request) {
+    BookingCommand.Cancel command = request.toCommand(bookingId, userContext);
+    bookingService.cancelBooking(command);
+  }
 }

--- a/src/main/java/com/goggles/mentoring_service/presentation/BookingController.java
+++ b/src/main/java/com/goggles/mentoring_service/presentation/BookingController.java
@@ -61,4 +61,14 @@ public class BookingController {
         new BookingCommand.Accept(bookingId, userContext.userId(), userContext.userType());
     bookingService.acceptBooking(command);
   }
+
+  @ResponseStatus(HttpStatus.OK)
+  @PostMapping("/{bookingId}/rejection")
+  public void rejectBooking(
+      UserContext userContext,
+      @PathVariable UUID bookingId,
+      @Valid @RequestBody BookingRequest.Reject request) {
+    BookingCommand.Reject command = request.toCommand(bookingId, userContext);
+    bookingService.rejectBooking(command);
+  }
 }

--- a/src/main/java/com/goggles/mentoring_service/presentation/dto/BookingRequest.java
+++ b/src/main/java/com/goggles/mentoring_service/presentation/dto/BookingRequest.java
@@ -6,6 +6,7 @@ import com.goggles.mentoring_service.domain.booking.MentoringBookingId;
 import com.goggles.mentoring_service.domain.booking.SessionSlot;
 import com.goggles.mentoring_service.presentation.support.UserContext;
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
 import java.time.LocalDate;
@@ -33,6 +34,12 @@ public class BookingRequest {
   public record BookingTimeSlot(
       @NotNull LocalDate date, @NotNull LocalTime startTime, @NotNull LocalTime endTime) {}
 
+  public record Reject(@NotBlank String reason) {
+    public BookingCommand.Reject toCommand(UUID bookingId, UserContext userContext) {
+      return new BookingCommand.Reject(
+          bookingId, userContext.userId(), userContext.userType(), reason());
+	}
+}
   public record PaymentFailed(
         @NotNull UUID mentoringBookingId, @NotNull UUID orderId, @NotNull String failureReason
   ) {

--- a/src/main/java/com/goggles/mentoring_service/presentation/dto/BookingRequest.java
+++ b/src/main/java/com/goggles/mentoring_service/presentation/dto/BookingRequest.java
@@ -48,4 +48,11 @@ public class BookingRequest {
         return new BookingCommand.PaymentFailed(mentoringBookingId, orderId(), failureReason());
     }
   }
+
+  public record Cancel(@NotBlank String reason) {
+    public BookingCommand.Cancel toCommand(UUID bookingId, UserContext userContext) {
+      return new BookingCommand.Cancel(
+          bookingId, userContext.userId(), userContext.userType(), reason());
+    }
+  }
 }

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -22,6 +22,12 @@ spring:
         default_batch_fetch_size: 100
         default_schema: mentoring
 
+  kafka:
+    bootstrap-servers: ${KAFKA_BOOTSTRAP_SERVERS:localhost:9092}
+    producer:
+      key-serializer: org.apache.kafka.common.serialization.StringSerializer
+      value-serializer: org.apache.kafka.common.serialization.StringSerializer
+
 resilience4j:
   circuitbreaker:
     instances:
@@ -65,6 +71,9 @@ spring:
   config:
     activate:
       on-profile: local
+
+  autoconfigure:
+    exclude: org.springframework.boot.autoconfigure.kafka.KafkaAutoConfiguration
 
   jpa:
     hibernate:

--- a/src/test/java/com/goggles/mentoring_service/application/service/BookingServiceIntegrationTest.java
+++ b/src/test/java/com/goggles/mentoring_service/application/service/BookingServiceIntegrationTest.java
@@ -1,38 +1,21 @@
 package com.goggles.mentoring_service.application.service;
 
-import static com.goggles.mentoring_service.domain.booking.BookingFixture.*;
-import static com.goggles.mentoring_service.domain.mentoring.MentoringFixture.*;
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-
 import com.goggles.common.exception.ForbiddenException;
 import com.goggles.common.pagination.CommonPageRequest;
 import com.goggles.mentoring_service.application.command.BookingCommand;
 import com.goggles.mentoring_service.application.command.MenteeInfo;
-import com.goggles.mentoring_service.domain.booking.BookingSearchCondition;
-import com.goggles.mentoring_service.domain.booking.BookingSort;
 import com.goggles.mentoring_service.application.result.BookingResult;
 import com.goggles.mentoring_service.config.TestAuditConfig;
 import com.goggles.mentoring_service.domain._common.UserType;
-import com.goggles.mentoring_service.domain.booking.BookingStatus;
-import com.goggles.mentoring_service.domain.booking.MentoringBooking;
-import com.goggles.mentoring_service.domain.booking.MentoringBookingId;
-import com.goggles.mentoring_service.domain.booking.SessionSlot;
+import com.goggles.mentoring_service.domain.booking.*;
 import com.goggles.mentoring_service.domain.booking.exception.BookingNotFoundException;
 import com.goggles.mentoring_service.domain.booking.repository.MentoringBookingRepository;
 import com.goggles.mentoring_service.domain.category.MentoringCategory;
 import com.goggles.mentoring_service.domain.category.repository.MentoringCategoryRepository;
-import com.goggles.mentoring_service.domain.mentoring.Format;
-import com.goggles.mentoring_service.domain.mentoring.Mentoring;
-import com.goggles.mentoring_service.domain.mentoring.MentoringId;
-import com.goggles.mentoring_service.domain.mentoring.MentoringType;
-import com.goggles.mentoring_service.domain.mentoring.SessionStatus;
+import com.goggles.mentoring_service.domain.mentoring.*;
 import com.goggles.mentoring_service.domain.mentoring.exception.MentoringNotFoundException;
 import com.goggles.mentoring_service.domain.mentoring.repository.MentoringRepository;
 import jakarta.persistence.EntityManager;
-import java.time.LocalDate;
-import java.util.List;
-import java.util.UUID;
 import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -44,6 +27,17 @@ import org.springframework.data.domain.Page;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDate;
+import java.util.List;
+import java.util.UUID;
+
+import static com.goggles.mentoring_service.domain.booking.BookingFixture.*;
+import static com.goggles.mentoring_service.domain.booking.BookingFixture.sessionSlot;
+import static com.goggles.mentoring_service.domain.mentoring.MentoringFixture.*;
+import static com.goggles.mentoring_service.domain.mentoring.MentoringFixture.sessionSlot;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
 @SpringBootTest
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.ANY)
 @Import(TestAuditConfig.class)
@@ -51,340 +45,350 @@ import org.springframework.transaction.annotation.Transactional;
 @Transactional
 class BookingServiceIntegrationTest {
 
-  private static final Logger log = LoggerFactory.getLogger(BookingServiceIntegrationTest.class);
-
-  private static final UUID OTHER_MENTEE_ID =
-      UUID.fromString("00000000-0000-0000-0000-000000000099");
-  private static final UUID UNAUTHORIZED_USER_ID =
-      UUID.fromString("00000000-0000-0000-0000-000000000199");
-  private static final String OTHER_MENTEE_NAME = "다른학생";
-  private static final int PAGE_NUMBER = 0;
-  private static final int PAGE_SIZE = 10;
-  private static final LocalDate MENTORING_SESSION_DATE_2 =
-      com.goggles.mentoring_service.domain.mentoring.MentoringFixture.SESSION_DATE_2;
-
-  @Autowired private BookingService bookingService;
-  @Autowired private MentoringRepository mentoringRepository;
-  @Autowired private MentoringBookingRepository bookingRepository;
-  @Autowired private MentoringCategoryRepository categoryRepository;
-  @Autowired private EntityManager em;
-
-  @Test
-  void createBooking_persists_to_db() {
-    UUID mentoringId = saveMentoringWithSession(SESSION_DATE_1);
-    BookingCommand.Create command = bookingCommand(mentoringId, sessionSlot(SESSION_DATE_1));
-
-    BookingResult.Create result = bookingService.createBooking(command);
-
-    em.flush();
-    em.clear();
-
-    MentoringBooking booking =
-        bookingRepository.findById(new MentoringBookingId(result.enrollmentId())).orElseThrow();
-
-    log.info("==== 생성된 예약 ====");
-    log.info("bookingId  : {}", booking.getMentoringBookingId().bookingId());
-    log.info("status     : {}", booking.getStatus());
-    log.info("mentoringId: {}", booking.getBookedMentoring().getMentoringId());
-    log.info("menteeId   : {}", booking.getMentee().getId());
-
-    assertThat(booking.getStatus()).isEqualTo(BookingStatus.PENDING);
-    assertThat(booking.getBookedMentoring().getMentoringId()).isEqualTo(mentoringId);
-    assertThat(booking.getMentee().getId()).isEqualTo(MENTEE_ID);
-  }
-
-  @Test
-  void createBooking_marks_session_as_booked() {
-    UUID mentoringId = saveMentoringWithSession(SESSION_DATE_1);
-    BookingCommand.Create command = bookingCommand(mentoringId, sessionSlot(SESSION_DATE_1));
-
-    bookingService.createBooking(command);
-
-    em.flush();
-    em.clear();
-
-    Mentoring mentoring = mentoringRepository.findById(new MentoringId(mentoringId)).orElseThrow();
-    SessionStatus sessionStatus =
-        mentoring.getSessions().stream()
-            .filter(s -> s.getSessionDate().equals(SESSION_DATE_1))
-            .findFirst()
-            .orElseThrow()
-            .getStatus();
-
-    log.info("==== 세션 상태 확인 ====");
-    log.info("세션 날짜: {} | 상태: {}", SESSION_DATE_1, sessionStatus);
-
-    assertThat(sessionStatus).isEqualTo(SessionStatus.BOOKED);
-  }
-
-  @Test
-  void createBooking_mentoring_not_found() {
-    UUID unknownId = UUID.randomUUID();
-    BookingCommand.Create command = bookingCommand(unknownId, sessionSlot());
-
-    assertThatThrownBy(() -> bookingService.createBooking(command))
-        .isInstanceOf(MentoringNotFoundException.class);
-  }
-
-  // ── 상세 조회 ─────────────────────────────────────────────────────────────
-
-  @Test
-  void getBooking_byMentee_success() {
-    UUID mentoringId = saveMentoringWithSession(SESSION_DATE_1);
-    BookingResult.Create created =
-        bookingService.createBooking(bookingCommand(mentoringId, sessionSlot(SESSION_DATE_1)));
-
-    em.flush();
-    em.clear();
-
-    BookingResult.Detail result =
-        bookingService.getBooking(created.enrollmentId(), MENTEE_ID, UserType.STUDENT);
-
-    log.info("==== 멘티 예약 상세 조회 결과 ====");
-    log.info("bookingId: {}", result.bookingId());
-    log.info("menteeId : {}", result.mentee().menteeId());
-    log.info("status   : {}", result.status());
-
-    assertThat(result.bookingId()).isEqualTo(created.enrollmentId());
-    assertThat(result.mentee().menteeId()).isEqualTo(MENTEE_ID);
-    assertThat(result.status()).isEqualTo(BookingStatus.PENDING);
-  }
-
-  @Test
-  void getBooking_byMentor_success() {
-    UUID mentoringId = saveMentoringWithSession(SESSION_DATE_1);
-    BookingResult.Create created =
-        bookingService.createBooking(bookingCommand(mentoringId, sessionSlot(SESSION_DATE_1)));
-
-    em.flush();
-    em.clear();
-
-    BookingResult.Detail result =
-        bookingService.getBooking(created.enrollmentId(), MENTOR_ID, UserType.INSTRUCTOR);
-
-    log.info("==== 멘토 예약 상세 조회 결과 ====");
-    log.info("bookingId: {}", result.bookingId());
-    log.info("status   : {}", result.status());
-
-    assertThat(result.bookingId()).isEqualTo(created.enrollmentId());
-    assertThat(result.status()).isEqualTo(BookingStatus.PENDING);
-  }
-
-  @Test
-  void getBooking_notFound() {
-    UUID unknownBookingId = UUID.randomUUID();
-
-    assertThatThrownBy(
-            () -> bookingService.getBooking(unknownBookingId, MENTEE_ID, UserType.STUDENT))
-        .isInstanceOf(BookingNotFoundException.class);
-  }
-
-  @Test
-  void getBooking_byOtherUser_forbidden() {
-    UUID mentoringId = saveMentoringWithSession(SESSION_DATE_1);
-    BookingResult.Create created =
-        bookingService.createBooking(bookingCommand(mentoringId, sessionSlot(SESSION_DATE_1)));
-
-    em.flush();
-    em.clear();
-
-    assertThatThrownBy(
-            () -> bookingService.getBooking(created.enrollmentId(), UNAUTHORIZED_USER_ID, UserType.STUDENT))
-        .isInstanceOf(ForbiddenException.class);
-  }
-
-  // ── 목록 조회 ─────────────────────────────────────────────────────────────
-
-  @Test
-  void getMyBookings_success() {
-    UUID mentoringId = saveMentoringWithSessions(SESSION_DATE_1, MENTORING_SESSION_DATE_2);
-
-    bookingService.createBooking(
-        bookingCommand(mentoringId, sessionSlot(SESSION_DATE_1), MENTEE_ID, MENTEE_NAME));
-    bookingService.createBooking(
-        bookingCommand(
-            mentoringId,
-            sessionSlot(MENTORING_SESSION_DATE_2),
-            OTHER_MENTEE_ID,
-            OTHER_MENTEE_NAME));
-
-    em.flush();
-    em.clear();
-
-    BookingSearchCondition condition =
-        new BookingSearchCondition(MENTEE_ID, UserType.STUDENT, null, BookingSort.CREATED_AT_DESC);
-    Page<BookingResult.Summary> result =
-        bookingService.getMyBookings(condition, CommonPageRequest.of(PAGE_NUMBER, PAGE_SIZE));
-
-    log.info("==== 내 예약 목록 조회 결과 ====");
-    log.info("총 {}건", result.getTotalElements());
-
-    assertThat(result.getContent()).hasSize(1);
-    assertThat(result.getContent().getFirst().menteeName()).isEqualTo(MENTEE_NAME);
-  }
+	private static final Logger log = LoggerFactory.getLogger(BookingServiceIntegrationTest.class);
+
+	private static final UUID OTHER_MENTEE_ID =
+			UUID.fromString("00000000-0000-0000-0000-000000000099");
+	private static final UUID UNAUTHORIZED_USER_ID =
+			UUID.fromString("00000000-0000-0000-0000-000000000199");
+	private static final String OTHER_MENTEE_NAME = "다른학생";
+	private static final int PAGE_NUMBER = 0;
+	private static final int PAGE_SIZE = 10;
+	private static final LocalDate MENTORING_SESSION_DATE_2 =
+			com.goggles.mentoring_service.domain.mentoring.MentoringFixture.SESSION_DATE_2;
+
+	@Autowired
+	private BookingService bookingService;
+	@Autowired
+	private MentoringRepository mentoringRepository;
+	@Autowired
+	private MentoringBookingRepository bookingRepository;
+	@Autowired
+	private MentoringCategoryRepository categoryRepository;
+	@Autowired
+	private EntityManager em;
+
+	@Test
+	void createBooking_persists_to_db() {
+		UUID mentoringId = saveMentoringWithSession(SESSION_DATE_1);
+		BookingCommand.Create command = bookingCommand(mentoringId, sessionSlot(SESSION_DATE_1));
+
+		BookingResult.Create result = bookingService.createBooking(command);
+
+		em.flush();
+		em.clear();
+
+		MentoringBooking booking =
+				bookingRepository.findById(new MentoringBookingId(result.enrollmentId()))
+						.orElseThrow();
+
+		log.info("==== 생성된 예약 ====");
+		log.info("bookingId  : {}", booking.getMentoringBookingId()
+				.bookingId());
+		log.info("status     : {}", booking.getStatus());
+		log.info("mentoringId: {}", booking.getBookedMentoring()
+				.getMentoringId());
+		log.info("menteeId   : {}", booking.getMentee()
+				.getId());
+
+		assertThat(booking.getStatus()).isEqualTo(BookingStatus.PENDING);
+		assertThat(booking.getBookedMentoring()
+				.getMentoringId()).isEqualTo(mentoringId);
+		assertThat(booking.getMentee()
+				.getId()).isEqualTo(MENTEE_ID);
+	}
+
+	@Test
+	void createBooking_marks_session_as_booked() {
+		UUID mentoringId = saveMentoringWithSession(SESSION_DATE_1);
+		BookingCommand.Create command = bookingCommand(mentoringId, sessionSlot(SESSION_DATE_1));
+
+		bookingService.createBooking(command);
+
+		em.flush();
+		em.clear();
+
+		Mentoring mentoring = mentoringRepository.findById(new MentoringId(mentoringId))
+				.orElseThrow();
+		SessionStatus sessionStatus = mentoring.getSessions()
+				.stream()
+				.filter(s -> s.getSessionDate()
+						.equals(SESSION_DATE_1))
+				.findFirst()
+				.orElseThrow()
+				.getStatus();
+
+		log.info("==== 세션 상태 확인 ====");
+		log.info("세션 날짜: {} | 상태: {}", SESSION_DATE_1, sessionStatus);
+
+		assertThat(sessionStatus).isEqualTo(SessionStatus.BOOKED);
+	}
+
+	@Test
+	void createBooking_mentoring_not_found() {
+		UUID unknownId = UUID.randomUUID();
+		BookingCommand.Create command = bookingCommand(unknownId, sessionSlot());
+
+		assertThatThrownBy(() -> bookingService.createBooking(command)).isInstanceOf(
+				MentoringNotFoundException.class);
+	}
+
+	// ── 상세 조회 ─────────────────────────────────────────────────────────────
+
+	@Test
+	void getBooking_byMentee_success() {
+		UUID mentoringId = saveMentoringWithSession(SESSION_DATE_1);
+		BookingResult.Create created = bookingService.createBooking(
+				bookingCommand(mentoringId, sessionSlot(SESSION_DATE_1)));
+
+		em.flush();
+		em.clear();
+
+		BookingResult.Detail result =
+				bookingService.getBooking(created.enrollmentId(), MENTEE_ID, UserType.STUDENT);
+
+		log.info("==== 멘티 예약 상세 조회 결과 ====");
+		log.info("bookingId: {}", result.bookingId());
+		log.info("menteeId : {}", result.mentee()
+				.menteeId());
+		log.info("status   : {}", result.status());
+
+		assertThat(result.bookingId()).isEqualTo(created.enrollmentId());
+		assertThat(result.mentee()
+				.menteeId()).isEqualTo(MENTEE_ID);
+		assertThat(result.status()).isEqualTo(BookingStatus.PENDING);
+	}
+
+	@Test
+	void getBooking_byMentor_success() {
+		UUID mentoringId = saveMentoringWithSession(SESSION_DATE_1);
+		BookingResult.Create created = bookingService.createBooking(
+				bookingCommand(mentoringId, sessionSlot(SESSION_DATE_1)));
+
+		em.flush();
+		em.clear();
+
+		BookingResult.Detail result =
+				bookingService.getBooking(created.enrollmentId(), MENTOR_ID, UserType.INSTRUCTOR);
+
+		log.info("==== 멘토 예약 상세 조회 결과 ====");
+		log.info("bookingId: {}", result.bookingId());
+		log.info("status   : {}", result.status());
+
+		assertThat(result.bookingId()).isEqualTo(created.enrollmentId());
+		assertThat(result.status()).isEqualTo(BookingStatus.PENDING);
+	}
+
+	@Test
+	void getBooking_notFound() {
+		UUID unknownBookingId = UUID.randomUUID();
+
+		assertThatThrownBy(() -> bookingService.getBooking(unknownBookingId, MENTEE_ID,
+				UserType.STUDENT)).isInstanceOf(BookingNotFoundException.class);
+	}
+
+	@Test
+	void getBooking_byOtherUser_forbidden() {
+		UUID mentoringId = saveMentoringWithSession(SESSION_DATE_1);
+		BookingResult.Create created = bookingService.createBooking(
+				bookingCommand(mentoringId, sessionSlot(SESSION_DATE_1)));
+
+		em.flush();
+		em.clear();
+
+		assertThatThrownBy(
+				() -> bookingService.getBooking(created.enrollmentId(), UNAUTHORIZED_USER_ID,
+						UserType.STUDENT)).isInstanceOf(ForbiddenException.class);
+	}
+
+	// ── 목록 조회 ─────────────────────────────────────────────────────────────
+
+	@Test
+	void getMyBookings_success() {
+		UUID mentoringId = saveMentoringWithSessions(SESSION_DATE_1, MENTORING_SESSION_DATE_2);
+
+		bookingService.createBooking(
+				bookingCommand(mentoringId, sessionSlot(SESSION_DATE_1), MENTEE_ID, MENTEE_NAME));
+		bookingService.createBooking(
+				bookingCommand(mentoringId, sessionSlot(MENTORING_SESSION_DATE_2), OTHER_MENTEE_ID,
+						OTHER_MENTEE_NAME));
+
+		em.flush();
+		em.clear();
+
+		BookingSearchCondition condition =
+				new BookingSearchCondition(MENTEE_ID, UserType.STUDENT, null,
+						BookingSort.CREATED_AT_DESC);
+		Page<BookingResult.Summary> result = bookingService.getMyBookings(condition,
+				CommonPageRequest.of(PAGE_NUMBER, PAGE_SIZE));
+
+		log.info("==== 내 예약 목록 조회 결과 ====");
+		log.info("총 {}건", result.getTotalElements());
+
+		assertThat(result.getContent()).hasSize(1);
+		assertThat(result.getContent()
+				.getFirst()
+				.menteeName()).isEqualTo(MENTEE_NAME);
+	}
+
+	@Test
+	void getMyBookings_empty() {
+		UUID mentoringId = saveMentoringWithSession(SESSION_DATE_1);
+		bookingService.createBooking(
+				bookingCommand(mentoringId, sessionSlot(SESSION_DATE_1), OTHER_MENTEE_ID,
+						OTHER_MENTEE_NAME));
+
+		em.flush();
+		em.clear();
+
+		BookingSearchCondition condition =
+				new BookingSearchCondition(MENTEE_ID, UserType.STUDENT, null,
+						BookingSort.CREATED_AT_DESC);
+		Page<BookingResult.Summary> result = bookingService.getMyBookings(condition,
+				CommonPageRequest.of(PAGE_NUMBER, PAGE_SIZE));
+
+		assertThat(result.getContent()).isEmpty();
+		assertThat(result.getTotalElements()).isZero();
+	}
+
+	// ── 헬퍼 ─────────────────────────────────────────────────────────────────
+
+	private UUID saveMentoringWithSession(LocalDate sessionDate) {
+		MentoringCategory category =
+				MentoringCategory.create(MENTOR_ID, UserType.MASTER, CATEGORY_NAME, CATEGORY_CODE);
+		categoryRepository.save(category);
+
+		Mentoring mentoring = defaultMentoringBuilder().categoryId(category.getMentoringCategoryId()
+						.categoryId())
+				.categoryName(category.getName())
+				.categoryCode(category.getCode())
+				.format(Format.SINGLE)
+				.mentoringType(MentoringType.ONE_ON_ONE)
+				.sessions(List.of(session(sessionDate)))
+				.build();
+		mentoringRepository.save(mentoring);
+
+		return mentoring.getMentoringId()
+				.mentoringId();
+	}
+
+	private UUID saveMentoringWithSessions(LocalDate firstDate, LocalDate secondDate) {
+		MentoringCategory category =
+				MentoringCategory.create(MENTOR_ID, UserType.MASTER, CATEGORY_NAME, CATEGORY_CODE);
+		categoryRepository.save(category);
+
+		Mentoring mentoring = defaultMentoringBuilder().categoryId(category.getMentoringCategoryId()
+						.categoryId())
+				.categoryName(category.getName())
+				.categoryCode(category.getCode())
+				.format(Format.SINGLE)
+				.mentoringType(MentoringType.ONE_ON_ONE)
+				.sessions(List.of(session(firstDate), session(secondDate)))
+				.build();
+		mentoringRepository.save(mentoring);
+
+		return mentoring.getMentoringId()
+				.mentoringId();
+	}
+
+	private BookingCommand.Create bookingCommand(UUID mentoringId, SessionSlot slot) {
+		MenteeInfo menteeInfo = new MenteeInfo(MENTEE_ID, UserType.STUDENT, MENTEE_NAME);
+		return new BookingCommand.Create(menteeInfo, mentoringId, List.of(slot), REQUEST_MESSAGE,
+				UUID.randomUUID());
+	}
+
+	@Test
+	void acceptBooking_persists_status_change() {
+		UUID mentoringId = saveMentoringWithSession(SESSION_DATE_1);
+		UUID bookingId = savePaymentCompletedBooking(mentoringId);
+
+		bookingService.acceptBooking(
+				new BookingCommand.Accept(bookingId, MENTOR_ID, UserType.INSTRUCTOR));
+
+		em.flush();
+		em.clear();
+
+		MentoringBooking booking = bookingRepository.findById(new MentoringBookingId(bookingId))
+				.orElseThrow();
+
+		log.info("==== 예약 승인 결과 ====");
+		log.info("bookingId: {} | status: {}", bookingId, booking.getStatus());
+
+		assertThat(booking.getStatus()).isEqualTo(BookingStatus.ACCEPTED);
+	}
+
+	@Test
+	void rejectBooking_persists_status_and_closure() {
+		UUID mentoringId = saveMentoringWithSession(SESSION_DATE_1);
+		UUID bookingId = savePaymentCompletedBooking(mentoringId);
+
+		bookingService.rejectBooking(
+				new BookingCommand.Reject(bookingId, MENTOR_ID, UserType.INSTRUCTOR,
+						REJECT_REASON));
+
+
+		MentoringBooking booking = bookingRepository.findById(new MentoringBookingId(bookingId))
+				.orElseThrow();
+
+		log.info("==== 예약 거절 결과 ====");
+		log.info("bookingId: {} | status: {} | reason: {}", bookingId, booking.getStatus(),
+				booking.getCloseReason());
+
+		assertThat(booking.getStatus()).isEqualTo(BookingStatus.REJECTED);
+		assertThat(booking.getCloseReason()).isEqualTo(REJECT_REASON);
+		assertThat(booking.getClosedBy()).isEqualTo(MENTOR_ID);
+	}
+
+	private UUID savePaymentCompletedBooking(UUID mentoringId) {
+		BookingCommand.Create command = bookingCommand(mentoringId, sessionSlot(SESSION_DATE_1));
+		BookingResult.Create result = bookingService.createBooking(command);
+
+		MentoringBooking booking =
+				bookingRepository.findById(new MentoringBookingId(result.enrollmentId()))
+						.orElseThrow();
+		booking.completePayment();
+		bookingRepository.save(booking);
+
+		return result.enrollmentId();
+	}
+
+	@Test
+	void cancelBooking_persists_status_and_closure() {
+		UUID mentoringId = saveMentoringWithSession(SESSION_DATE_1);
+		UUID bookingId = savePaymentCompletedBooking(mentoringId);
+
+		bookingService.cancelBooking(
+				new BookingCommand.Cancel(bookingId, MENTEE_ID, UserType.STUDENT, CANCEL_REASON));
+
+		em.flush();
+		em.clear();
+
+		MentoringBooking booking = bookingRepository.findById(new MentoringBookingId(bookingId))
+				.orElseThrow();
+
+		log.info("==== 예약 취소 결과 ====");
+		log.info("bookingId: {} | status: {} | reason: {}", bookingId, booking.getStatus(),
+				booking.getCloseReason());
+
+		assertThat(booking.getStatus()).isEqualTo(BookingStatus.CANCELED);
+		assertThat(booking.getCloseReason()).isEqualTo(CANCEL_REASON);
+		assertThat(booking.getClosedBy()).isEqualTo(MENTEE_ID);
+	}
+
+	@Test
+	void acceptBooking_booking_not_found() {
+		assertThatThrownBy(() -> bookingService.acceptBooking(
+				new BookingCommand.Accept(UUID.randomUUID(), MENTOR_ID,
+						UserType.INSTRUCTOR))).isInstanceOf(BookingNotFoundException.class);
+	}
+
+
+	private BookingCommand.Create bookingCommand(UUID mentoringId, SessionSlot slot, UUID menteeId,
+			String menteeName) {
+		MenteeInfo menteeInfo = new MenteeInfo(menteeId, UserType.STUDENT, menteeName);
+		return new BookingCommand.Create(menteeInfo, mentoringId, List.of(slot), REQUEST_MESSAGE,
+				null);
+	}
 
-  @Test
-  void getMyBookings_empty() {
-    UUID mentoringId = saveMentoringWithSession(SESSION_DATE_1);
-    bookingService.createBooking(
-        bookingCommand(mentoringId, sessionSlot(SESSION_DATE_1), OTHER_MENTEE_ID, OTHER_MENTEE_NAME));
-
-    em.flush();
-    em.clear();
-
-    BookingSearchCondition condition =
-        new BookingSearchCondition(MENTEE_ID, UserType.STUDENT, null, BookingSort.CREATED_AT_DESC);
-    Page<BookingResult.Summary> result =
-        bookingService.getMyBookings(condition, CommonPageRequest.of(PAGE_NUMBER, PAGE_SIZE));
-
-    assertThat(result.getContent()).isEmpty();
-    assertThat(result.getTotalElements()).isZero();
-  }
-
-  // ── 헬퍼 ─────────────────────────────────────────────────────────────────
-
-  private UUID saveMentoringWithSession(LocalDate sessionDate) {
-    MentoringCategory category =
-        MentoringCategory.create(MENTOR_ID, UserType.MASTER, CATEGORY_NAME, CATEGORY_CODE);
-    categoryRepository.save(category);
-
-    Mentoring mentoring =
-        defaultMentoringBuilder()
-            .categoryId(category.getMentoringCategoryId().categoryId())
-            .categoryName(category.getName())
-            .categoryCode(category.getCode())
-            .format(Format.SINGLE)
-            .mentoringType(MentoringType.ONE_ON_ONE)
-            .sessions(List.of(session(sessionDate)))
-            .build();
-    mentoringRepository.save(mentoring);
-
-    return mentoring.getMentoringId().mentoringId();
-  }
-
-  private UUID saveMentoringWithSessions(LocalDate firstDate, LocalDate secondDate) {
-    MentoringCategory category =
-        MentoringCategory.create(MENTOR_ID, UserType.MASTER, CATEGORY_NAME, CATEGORY_CODE);
-    categoryRepository.save(category);
-
-    Mentoring mentoring =
-        defaultMentoringBuilder()
-            .categoryId(category.getMentoringCategoryId().categoryId())
-            .categoryName(category.getName())
-            .categoryCode(category.getCode())
-            .format(Format.SINGLE)
-            .mentoringType(MentoringType.ONE_ON_ONE)
-            .sessions(List.of(session(firstDate), session(secondDate)))
-            .build();
-    mentoringRepository.save(mentoring);
-
-    return mentoring.getMentoringId().mentoringId();
-  }
-
-  private BookingCommand.Create bookingCommand(UUID mentoringId, SessionSlot slot) {
-    MenteeInfo menteeInfo = new MenteeInfo(MENTEE_ID, UserType.STUDENT, MENTEE_NAME);
-    return new BookingCommand.Create(menteeInfo, mentoringId, List.of(slot), REQUEST_MESSAGE, UUID.randomUUID());
-  }
-
-@Test
-  void acceptBooking_persists_status_change() {
-    UUID mentoringId = saveMentoringWithSession(SESSION_DATE_1);
-    UUID bookingId = savePaymentCompletedBooking(mentoringId);
-
-    bookingService.acceptBooking(
-        new BookingCommand.Accept(bookingId, MENTOR_ID, UserType.INSTRUCTOR));
-
-    em.flush();
-    em.clear();
-
-    MentoringBooking booking =
-        bookingRepository.findById(new MentoringBookingId(bookingId)).orElseThrow();
-
-    log.info("==== 예약 승인 결과 ====");
-    log.info("bookingId: {} | status: {}", bookingId, booking.getStatus());
-
-    assertThat(booking.getStatus()).isEqualTo(BookingStatus.ACCEPTED);
-  }
-
-  @Test
-  void rejectBooking_persists_status_and_closure() {
-    UUID mentoringId = saveMentoringWithSession(SESSION_DATE_1);
-    UUID bookingId = savePaymentCompletedBooking(mentoringId);
-
-    bookingService.rejectBooking(
-        new BookingCommand.Reject(bookingId, MENTOR_ID, UserType.INSTRUCTOR, REJECT_REASON));
-
-
-
-
-
-
-    MentoringBooking booking =
-        bookingRepository.findById(new MentoringBookingId(bookingId)).orElseThrow();
-
-    log.info("==== 예약 거절 결과 ====");
-    log.info(
-        "bookingId: {} | status: {} | reason: {}",
-        bookingId,
-        booking.getStatus(),
-        booking.getCloseReason());
-
-    assertThat(booking.getStatus()).isEqualTo(BookingStatus.REJECTED);
-    assertThat(booking.getCloseReason()).isEqualTo(REJECT_REASON);
-    assertThat(booking.getClosedBy()).isEqualTo(MENTOR_ID);
-  }
-
-  private UUID savePaymentCompletedBooking(UUID mentoringId) {
-    BookingCommand.Create command = bookingCommand(mentoringId, sessionSlot(SESSION_DATE_1));
-    BookingResult.Create result = bookingService.createBooking(command);
-
-    MentoringBooking booking =
-        bookingRepository.findById(new MentoringBookingId(result.enrollmentId())).orElseThrow();
-    booking.completePayment();
-    bookingRepository.save(booking);
-
-    return result.enrollmentId();
-  }
-
-  @Test
-  void cancelBooking_persists_status_and_closure() {
-    UUID mentoringId = saveMentoringWithSession(SESSION_DATE_1);
-    UUID bookingId = savePaymentCompletedBooking(mentoringId);
-
-    bookingService.cancelBooking(
-        new BookingCommand.Cancel(bookingId, MENTEE_ID, UserType.STUDENT, CANCEL_REASON));
-
-    em.flush();
-    em.clear();
-
-    MentoringBooking booking =
-        bookingRepository.findById(new MentoringBookingId(bookingId)).orElseThrow();
-
-    log.info("==== 예약 취소 결과 ====");
-    log.info(
-        "bookingId: {} | status: {} | reason: {}",
-        bookingId,
-        booking.getStatus(),
-        booking.getCloseReason());
-
-    assertThat(booking.getStatus()).isEqualTo(BookingStatus.CANCELED);
-    assertThat(booking.getCloseReason()).isEqualTo(CANCEL_REASON);
-    assertThat(booking.getClosedBy()).isEqualTo(MENTEE_ID);
-  }
-
-  @Test
-  void acceptBooking_booking_not_found() {
-    assertThatThrownBy(
-            () ->
-                bookingService.acceptBooking(
-                    new BookingCommand.Accept(UUID.randomUUID(), MENTOR_ID, UserType.INSTRUCTOR)))
-        .isInstanceOf(BookingNotFoundException.class);
-  }
-
-
-
-  private BookingCommand.Create bookingCommand(UUID mentoringId, SessionSlot slot, UUID menteeId, String menteeName) {
-    MenteeInfo menteeInfo = new MenteeInfo(menteeId, UserType.STUDENT, menteeName);
-    return new BookingCommand.Create(menteeInfo, mentoringId, List.of(slot), REQUEST_MESSAGE, null);
-  }
+
 }

--- a/src/test/java/com/goggles/mentoring_service/application/service/BookingServiceIntegrationTest.java
+++ b/src/test/java/com/goggles/mentoring_service/application/service/BookingServiceIntegrationTest.java
@@ -286,6 +286,103 @@ class BookingServiceIntegrationTest {
     return new BookingCommand.Create(menteeInfo, mentoringId, List.of(slot), REQUEST_MESSAGE, UUID.randomUUID());
   }
 
+@Test
+  void acceptBooking_persists_status_change() {
+    UUID mentoringId = saveMentoringWithSession(SESSION_DATE_1);
+    UUID bookingId = savePaymentCompletedBooking(mentoringId);
+
+    bookingService.acceptBooking(
+        new BookingCommand.Accept(bookingId, MENTOR_ID, UserType.INSTRUCTOR));
+
+    em.flush();
+    em.clear();
+
+    MentoringBooking booking =
+        bookingRepository.findById(new MentoringBookingId(bookingId)).orElseThrow();
+
+    log.info("==== 예약 승인 결과 ====");
+    log.info("bookingId: {} | status: {}", bookingId, booking.getStatus());
+
+    assertThat(booking.getStatus()).isEqualTo(BookingStatus.ACCEPTED);
+  }
+
+  @Test
+  void rejectBooking_persists_status_and_closure() {
+    UUID mentoringId = saveMentoringWithSession(SESSION_DATE_1);
+    UUID bookingId = savePaymentCompletedBooking(mentoringId);
+
+    bookingService.rejectBooking(
+        new BookingCommand.Reject(bookingId, MENTOR_ID, UserType.INSTRUCTOR, REJECT_REASON));
+
+
+
+
+
+
+    MentoringBooking booking =
+        bookingRepository.findById(new MentoringBookingId(bookingId)).orElseThrow();
+
+    log.info("==== 예약 거절 결과 ====");
+    log.info(
+        "bookingId: {} | status: {} | reason: {}",
+        bookingId,
+        booking.getStatus(),
+        booking.getCloseReason());
+
+    assertThat(booking.getStatus()).isEqualTo(BookingStatus.REJECTED);
+    assertThat(booking.getCloseReason()).isEqualTo(REJECT_REASON);
+    assertThat(booking.getClosedBy()).isEqualTo(MENTOR_ID);
+  }
+
+  private UUID savePaymentCompletedBooking(UUID mentoringId) {
+    BookingCommand.Create command = bookingCommand(mentoringId, sessionSlot(SESSION_DATE_1));
+    BookingResult.Create result = bookingService.createBooking(command);
+
+    MentoringBooking booking =
+        bookingRepository.findById(new MentoringBookingId(result.enrollmentId())).orElseThrow();
+    booking.completePayment();
+    bookingRepository.save(booking);
+
+    return result.enrollmentId();
+  }
+
+  @Test
+  void cancelBooking_persists_status_and_closure() {
+    UUID mentoringId = saveMentoringWithSession(SESSION_DATE_1);
+    UUID bookingId = savePaymentCompletedBooking(mentoringId);
+
+    bookingService.cancelBooking(
+        new BookingCommand.Cancel(bookingId, MENTEE_ID, UserType.STUDENT, CANCEL_REASON));
+
+    em.flush();
+    em.clear();
+
+    MentoringBooking booking =
+        bookingRepository.findById(new MentoringBookingId(bookingId)).orElseThrow();
+
+    log.info("==== 예약 취소 결과 ====");
+    log.info(
+        "bookingId: {} | status: {} | reason: {}",
+        bookingId,
+        booking.getStatus(),
+        booking.getCloseReason());
+
+    assertThat(booking.getStatus()).isEqualTo(BookingStatus.CANCELED);
+    assertThat(booking.getCloseReason()).isEqualTo(CANCEL_REASON);
+    assertThat(booking.getClosedBy()).isEqualTo(MENTEE_ID);
+  }
+
+  @Test
+  void acceptBooking_booking_not_found() {
+    assertThatThrownBy(
+            () ->
+                bookingService.acceptBooking(
+                    new BookingCommand.Accept(UUID.randomUUID(), MENTOR_ID, UserType.INSTRUCTOR)))
+        .isInstanceOf(BookingNotFoundException.class);
+  }
+
+
+
   private BookingCommand.Create bookingCommand(UUID mentoringId, SessionSlot slot, UUID menteeId, String menteeName) {
     MenteeInfo menteeInfo = new MenteeInfo(menteeId, UserType.STUDENT, menteeName);
     return new BookingCommand.Create(menteeInfo, mentoringId, List.of(slot), REQUEST_MESSAGE, null);

--- a/src/test/java/com/goggles/mentoring_service/application/service/BookingServiceTest.java
+++ b/src/test/java/com/goggles/mentoring_service/application/service/BookingServiceTest.java
@@ -8,6 +8,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.verify;
 
+import com.goggles.common.event.Events;
 import com.goggles.common.exception.ForbiddenException;
 import com.goggles.common.pagination.CommonPageRequest;
 import com.goggles.mentoring_service.application.command.BookingCommand;
@@ -16,6 +17,10 @@ import com.goggles.mentoring_service.domain.booking.BookingSearchCondition;
 import com.goggles.mentoring_service.domain.booking.BookingSort;
 import com.goggles.mentoring_service.application.result.BookingResult;
 import com.goggles.mentoring_service.domain._common.UserType;
+import com.goggles.mentoring_service.domain.booking.BookingStatus;
+import com.goggles.mentoring_service.domain.booking.MentoringBooking;
+import com.goggles.mentoring_service.domain.booking.exception.BookingNotFoundException;
+import com.goggles.mentoring_service.domain.booking.exception.UnauthorizedBookingAccessException;
 import com.goggles.mentoring_service.domain.booking.MentoringBooking;
 import com.goggles.mentoring_service.domain.booking.exception.BookingNotFoundException;
 import com.goggles.mentoring_service.domain.booking.repository.MentoringBookingRepository;
@@ -92,6 +97,90 @@ class BookingServiceTest {
 
     assertThatThrownBy(() -> bookingService.createBooking(command))
         .isInstanceOf(RuntimeException.class);
+  }
+
+  @Test
+  void acceptBooking_success() {
+    MentoringBooking booking = paymentCompletedBooking();
+    given(bookingRepository.findById(any())).willReturn(Optional.of(booking));
+
+    bookingService.acceptBooking(
+        new BookingCommand.Accept(booking.getMentoringBookingId().bookingId(), MENTOR_ID, UserType.INSTRUCTOR));
+
+    assertThat(booking.getStatus()).isEqualTo(BookingStatus.ACCEPTED);
+  }
+
+  @Test
+  void acceptBooking_booking_not_found() {
+    given(bookingRepository.findById(any())).willReturn(Optional.empty());
+
+    assertThatThrownBy(
+            () -> bookingService.acceptBooking(
+                new BookingCommand.Accept(UUID.randomUUID(), MENTOR_ID, UserType.INSTRUCTOR)))
+        .isInstanceOf(BookingNotFoundException.class);
+  }
+
+  @Test
+  void rejectBooking_success() {
+    MentoringBooking booking = paymentCompletedBooking();
+    given(bookingRepository.findById(any())).willReturn(Optional.of(booking));
+
+    bookingService.rejectBooking(
+        new BookingCommand.Reject(
+            booking.getMentoringBookingId().bookingId(), MENTOR_ID, UserType.INSTRUCTOR, REJECT_REASON));
+
+    assertThat(booking.getStatus()).isEqualTo(BookingStatus.REJECTED);
+  }
+
+  @Test
+  void rejectBooking_booking_not_found() {
+    given(bookingRepository.findById(any())).willReturn(Optional.empty());
+
+    assertThatThrownBy(
+            () ->
+                bookingService.rejectBooking(
+                    new BookingCommand.Reject(
+                        UUID.randomUUID(), MENTOR_ID, UserType.INSTRUCTOR, REJECT_REASON)))
+        .isInstanceOf(BookingNotFoundException.class);
+  }
+
+  @Test
+  void cancelBooking_success() {
+    MentoringBooking booking = paymentCompletedBooking();
+    given(bookingRepository.findById(any())).willReturn(Optional.of(booking));
+
+    bookingService.cancelBooking(
+        new BookingCommand.Cancel(
+            booking.getMentoringBookingId().bookingId(), MENTEE_ID, UserType.STUDENT, CANCEL_REASON));
+
+    assertThat(booking.getStatus()).isEqualTo(BookingStatus.CANCELED);
+  }
+
+  @Test
+  void cancelBooking_booking_not_found() {
+    given(bookingRepository.findById(any())).willReturn(Optional.empty());
+
+    assertThatThrownBy(
+            () ->
+                bookingService.cancelBooking(
+                    new BookingCommand.Cancel(
+                        UUID.randomUUID(), MENTEE_ID, UserType.STUDENT, CANCEL_REASON)))
+        .isInstanceOf(BookingNotFoundException.class);
+  }
+
+  @Test
+  void acceptBooking_unauthorized() {
+    MentoringBooking booking = paymentCompletedBooking();
+    given(bookingRepository.findById(any())).willReturn(Optional.of(booking));
+
+    assertThatThrownBy(
+            () ->
+                bookingService.acceptBooking(
+                    new BookingCommand.Accept(
+                        booking.getMentoringBookingId().bookingId(),
+                        UUID.randomUUID(),
+                        UserType.INSTRUCTOR)))
+        .isInstanceOf(UnauthorizedBookingAccessException.class);
   }
 
   private BookingCommand.Create defaultCommand(Mentoring mentoring) {

--- a/src/test/java/com/goggles/mentoring_service/application/service/BookingServiceTest.java
+++ b/src/test/java/com/goggles/mentoring_service/application/service/BookingServiceTest.java
@@ -43,8 +43,8 @@ class BookingServiceTest {
   @InjectMocks private BookingService bookingService;
 
   @Mock private MentoringBookingRepository bookingRepository;
-
   @Mock private MentoringRepository mentoringRepository;
+  @Mock private Events events;
 
   @Test
   void createBooking_success() {

--- a/src/test/java/com/goggles/mentoring_service/domain/booking/MentoringBookingTest.java
+++ b/src/test/java/com/goggles/mentoring_service/domain/booking/MentoringBookingTest.java
@@ -186,4 +186,32 @@ class MentoringBookingTest {
             () -> booking.cancel(MENTEE_ID, UserType.STUDENT, CANCEL_REASON, BEFORE_DEADLINE))
         .isInstanceOf(InvalidBookingStatusTransitionException.class);
   }
+
+  @Test
+  void reject_from_accepted_status() {
+    MentoringBooking booking = acceptedBooking();
+
+    assertThatThrownBy(
+            () -> booking.reject(MENTOR_ID, UserType.INSTRUCTOR, REJECT_REASON, LocalDateTime.now()))
+        .isInstanceOf(InvalidBookingStatusTransitionException.class);
+  }
+
+  @Test
+  void reject_by_student() {
+    MentoringBooking booking = paymentCompletedBooking();
+
+    assertThatThrownBy(
+            () -> booking.reject(MENTEE_ID, UserType.STUDENT, REJECT_REASON, LocalDateTime.now()))
+        .isInstanceOf(UnauthorizedBookingAccessException.class);
+  }
+
+  @Test
+  void cancel_from_payment_failed() {
+    MentoringBooking booking = pendingBooking();
+    booking.failPayment( "결제 실패 사유", LocalDateTime.now());
+
+    assertThatThrownBy(
+            () -> booking.cancel(MENTEE_ID, UserType.STUDENT, CANCEL_REASON, BEFORE_DEADLINE))
+        .isInstanceOf(InvalidBookingStatusTransitionException.class);
+  }
 }

--- a/src/test/java/com/goggles/mentoring_service/presentation/BookingControllerTest.java
+++ b/src/test/java/com/goggles/mentoring_service/presentation/BookingControllerTest.java
@@ -4,6 +4,8 @@ import static com.goggles.mentoring_service.domain.booking.BookingFixture.*;
 import static com.goggles.mentoring_service.domain.mentoring.MentoringFixture.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.willDoNothing;
+import static org.mockito.BDDMockito.willThrow;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
@@ -18,6 +20,8 @@ import com.goggles.mentoring_service.application.service.BookingService;
 import com.goggles.mentoring_service.domain._common.UserType;
 import com.goggles.mentoring_service.domain.booking.MentoringBookingId;
 import com.goggles.mentoring_service.domain.booking.exception.BookingNotFoundException;
+import com.goggles.mentoring_service.domain.booking.exception.InvalidBookingStatusTransitionException;
+import com.goggles.mentoring_service.domain.booking.exception.UnauthorizedBookingAccessException;
 import com.goggles.mentoring_service.domain.mentoring.MentoringId;
 import com.goggles.mentoring_service.domain.mentoring.exception.MentoringNotFoundException;
 import com.goggles.mentoring_service.infrastructure.config.WebMvcConfig;
@@ -25,6 +29,7 @@ import com.goggles.mentoring_service.presentation.dto.BookingRequest;
 import com.goggles.mentoring_service.presentation.support.TestHeaders;
 import com.goggles.mentoring_service.presentation.support.UserContextArgumentResolver;
 import java.util.List;
+import java.util.Map;
 import java.util.UUID;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -210,6 +215,196 @@ class BookingControllerTest {
         .andExpect(status().isOk())
         .andExpect(jsonPath("$.content.length()").value(0))
         .andExpect(jsonPath("$.totalElements").value(0));
+  }
+
+  @Test
+  void acceptBooking_success() throws Exception {
+    UUID bookingId = UUID.randomUUID();
+    willDoNothing().given(bookingService).acceptBooking(any());
+
+    mockMvc
+        .perform(
+            post("/api/v1/mentoring-bookings/{bookingId}/acceptance", bookingId)
+                .headers(TestHeaders.headersFor(UserType.INSTRUCTOR)))
+        .andDo(print())
+        .andExpect(status().isOk());
+  }
+
+  @Test
+  void acceptBooking_booking_not_found() throws Exception {
+    UUID bookingId = UUID.randomUUID();
+    willThrow(new BookingNotFoundException(new MentoringBookingId(bookingId)))
+        .given(bookingService).acceptBooking(any());
+
+    mockMvc
+        .perform(
+            post("/api/v1/mentoring-bookings/{bookingId}/acceptance", bookingId)
+                .headers(TestHeaders.headersFor(UserType.INSTRUCTOR)))
+
+
+
+
+
+
+        .andDo(print())
+        .andExpect(status().isNotFound())
+        .andExpect(jsonPath("$.title").value("Not Found"));
+  }
+
+  @Test
+  void rejectBooking_success() throws Exception {
+    UUID bookingId = UUID.randomUUID();
+    willDoNothing().given(bookingService).rejectBooking(any());
+
+    mockMvc
+        .perform(
+            post("/api/v1/mentoring-bookings/{bookingId}/rejection", bookingId)
+                .contentType(MediaType.APPLICATION_JSON)
+                .headers(TestHeaders.headersFor(UserType.INSTRUCTOR))
+                .content(objectMapper.writeValueAsString(Map.of("reason", REJECT_REASON))))
+        .andDo(print())
+        .andExpect(status().isOk());
+  }
+
+  @Test
+  void rejectBooking_fails_without_reason() throws Exception {
+    UUID bookingId = UUID.randomUUID();
+
+    mockMvc
+        .perform(
+            post("/api/v1/mentoring-bookings/{bookingId}/rejection", bookingId)
+                .contentType(MediaType.APPLICATION_JSON)
+                .headers(TestHeaders.headersFor(UserType.INSTRUCTOR))
+                .content("{}"))
+        .andExpect(status().isBadRequest());
+  }
+
+  @Test
+  void cancelBooking_success() throws Exception {
+    UUID bookingId = UUID.randomUUID();
+    willDoNothing().given(bookingService).cancelBooking(any());
+
+    mockMvc
+        .perform(
+            post("/api/v1/mentoring-bookings/{bookingId}/cancellation", bookingId)
+                .contentType(MediaType.APPLICATION_JSON)
+                .headers(TestHeaders.headersFor(UserType.STUDENT))
+                .content(objectMapper.writeValueAsString(Map.of("reason", CANCEL_REASON))))
+        .andDo(print())
+        .andExpect(status().isOk());
+  }
+
+  @Test
+  void cancelBooking_fails_without_reason() throws Exception {
+    UUID bookingId = UUID.randomUUID();
+
+    mockMvc
+        .perform(
+            post("/api/v1/mentoring-bookings/{bookingId}/cancellation", bookingId)
+                .contentType(MediaType.APPLICATION_JSON)
+                .headers(TestHeaders.headersFor(UserType.STUDENT))
+                .content("{}"))
+        .andExpect(status().isBadRequest());
+  }
+
+  @Test
+  void rejectBooking_booking_not_found() throws Exception {
+    UUID bookingId = UUID.randomUUID();
+    willThrow(new BookingNotFoundException(new MentoringBookingId(bookingId)))
+        .given(bookingService)
+        .rejectBooking(any());
+
+    mockMvc
+        .perform(
+            post("/api/v1/mentoring-bookings/{bookingId}/rejection", bookingId)
+                .contentType(MediaType.APPLICATION_JSON)
+                .headers(TestHeaders.headersFor(UserType.INSTRUCTOR))
+                .content(objectMapper.writeValueAsString(Map.of("reason", REJECT_REASON))))
+        .andExpect(status().isNotFound())
+        .andExpect(jsonPath("$.title").value("Not Found"));
+  }
+
+  @Test
+  void cancelBooking_booking_not_found() throws Exception {
+    UUID bookingId = UUID.randomUUID();
+    willThrow(new BookingNotFoundException(new MentoringBookingId(bookingId)))
+        .given(bookingService)
+        .cancelBooking(any());
+
+    mockMvc
+        .perform(
+            post("/api/v1/mentoring-bookings/{bookingId}/cancellation", bookingId)
+                .contentType(MediaType.APPLICATION_JSON)
+                .headers(TestHeaders.headersFor(UserType.STUDENT))
+                .content(objectMapper.writeValueAsString(Map.of("reason", CANCEL_REASON))))
+        .andExpect(status().isNotFound())
+        .andExpect(jsonPath("$.title").value("Not Found"));
+  }
+
+  @Test
+  void acceptBooking_unauthorized() throws Exception {
+    UUID bookingId = UUID.randomUUID();
+    willThrow(UnauthorizedBookingAccessException.noPermissionToProcess())
+        .given(bookingService)
+        .acceptBooking(any());
+
+    mockMvc
+        .perform(
+            post("/api/v1/mentoring-bookings/{bookingId}/acceptance", bookingId)
+                .headers(TestHeaders.headersFor(UserType.INSTRUCTOR)))
+        .andExpect(status().isForbidden())
+        .andExpect(jsonPath("$.title").value("Forbidden"));
+  }
+
+  @Test
+  void rejectBooking_unauthorized() throws Exception {
+    UUID bookingId = UUID.randomUUID();
+    willThrow(UnauthorizedBookingAccessException.noPermissionToProcess())
+        .given(bookingService)
+        .rejectBooking(any());
+
+    mockMvc
+        .perform(
+            post("/api/v1/mentoring-bookings/{bookingId}/rejection", bookingId)
+                .contentType(MediaType.APPLICATION_JSON)
+                .headers(TestHeaders.headersFor(UserType.STUDENT))
+                .content(objectMapper.writeValueAsString(Map.of("reason", REJECT_REASON))))
+        .andExpect(status().isForbidden())
+        .andExpect(jsonPath("$.title").value("Forbidden"));
+  }
+
+  @Test
+  void cancelBooking_unauthorized() throws Exception {
+    UUID bookingId = UUID.randomUUID();
+    willThrow(UnauthorizedBookingAccessException.noPermissionToCancel())
+        .given(bookingService)
+        .cancelBooking(any());
+
+    mockMvc
+        .perform(
+            post("/api/v1/mentoring-bookings/{bookingId}/cancellation", bookingId)
+                .contentType(MediaType.APPLICATION_JSON)
+                .headers(TestHeaders.headersFor(UserType.STUDENT))
+                .content(objectMapper.writeValueAsString(Map.of("reason", CANCEL_REASON))))
+        .andExpect(status().isForbidden())
+        .andExpect(jsonPath("$.title").value("Forbidden"));
+  }
+
+  @Test
+  void acceptBooking_invalid_status() throws Exception {
+    UUID bookingId = UUID.randomUUID();
+    willThrow(InvalidBookingStatusTransitionException.cannotAccept(
+            com.goggles.mentoring_service.domain.booking.BookingStatus.PENDING))
+        .given(bookingService)
+        .acceptBooking(any());
+
+    mockMvc
+        .perform(
+            post("/api/v1/mentoring-bookings/{bookingId}/acceptance", bookingId)
+                .headers(TestHeaders.headersFor(UserType.INSTRUCTOR)))
+        .andDo(print())
+        .andExpect(status().isBadRequest())
+        .andExpect(jsonPath("$.title").value("Invalid mentoring request"));
   }
 
   private BookingRequest.Create defaultRequest() {


### PR DESCRIPTION
### 📌 관련 이슈
- close #21

### 💡 작업 내용
- 멘토링 예약 수락          
- 멘토링 예약 거절
- 멘토링 예약 취소

### 🔍 변경 이유
- 멘토(수락/거절)와 멘티(취소)가 예약 상태를 변경할 수 있는 API가 필요함

### 📝 리뷰 포인트 (선택)
- 이벤트 발행: 상태 변경(수락/거절/취소) 시 각각 booking.accepted / booking.rejected / booking.canceled 토픽으로      
  도메인 이벤트를 발행함 — BookingService, EventInfraConfig 참고
 - 권한 검증: booking.accept() / reject() / cancel() 내부 도메인 로직에서 요청자의 UserType을 검증함

### 🧠 기타 참고 사항
(참고 문서, 스크린샷 등)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 예약 승인, 거절, 취소 기능 추가
  * 예약 상태 변경 시 이벤트 기반 알림 시스템 구현
  * 예약 세션 정보의 향상된 데이터 구조 제공

* **테스트**
  * 예약 상태 전환 및 권한 검증 테스트 추가
  * 오류 처리 및 유효성 검사 테스트 확대
<!-- end of auto-generated comment: release notes by coderabbit.ai -->