### PR TITLE
fix: 인증정보 변수 이름 재설정

### DIFF
--- a/.github/workflows/generate-openapi.yml
+++ b/.github/workflows/generate-openapi.yml
@@ -25,7 +25,7 @@ jobs:
         run: chmod +x ./gradlew
 
       - name: Generate OpenAPI Spec
-        run: ./gradlew generateOpenApiDocs --no-daemon -Pgpr.user=${{ github.actor }} -Pgpr.key=${{ secrets.GITHUB_TOKEN }}
+        run: ./gradlew generateOpenApiDocs --no-daemon -PGitHubPackagesUsername=${{ github.actor }} -PGitHubPackagesPassword=${{ secrets.GITHUB_TOKEN }}
 
       - name: Commit OpenAPI spec
         run: |


### PR DESCRIPTION
💡 작업 내용                                                                                                             
  - generate-openapi.yml의 Gradle 파라미터 이름을 build.gradle과 일치하도록 수정
  
  🔍 변경 이유 
  - generate-openapi.yml이 GitHub Packages 인증정보를 -Pgpr.user / -Pgpr.key로 전달했으나, build.gradle은               
  findProperty("GitHubPackagesUsername") / findProperty("GitHubPackagesPassword")로 읽고 있어 파라미터 이름 불일치로
  인증정보가 빈 문자열로 처리됨                                                                                         
  - 결과적으로 com.goggles:common-library 의존성 다운로드 시 401 Unauthorized 발생
