### PR TITLE
[Feat] event and config

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -205,12 +205,36 @@ jobs:
 
             # Kafka SSL truststore 복원
             mkdir -p $APP_DIR/ssl
-            echo "${{ secrets.TRUSTSTORE_JKS_B64 }}" | base64 -d > $APP_DIR/ssl/kafka.truststore.jks
+
+            TRUSTSTORE_B64="${{ secrets.TRUSTSTORE_JKS_B64 }}"
+            echo "[SSL] TRUSTSTORE_JKS_B64 secret 길이: ${#TRUSTSTORE_B64}"
+            if [ -z "$TRUSTSTORE_B64" ]; then
+              echo "[SSL] ❌ TRUSTSTORE_JKS_B64 secret이 비어있음"
+              exit 1
+            fi
+
+            echo "$TRUSTSTORE_B64" | base64 -d > $APP_DIR/ssl/kafka.truststore.jks
+
+            echo "[SSL] 파일 경로: $APP_DIR/ssl/kafka.truststore.jks"
+            if [ -f "$APP_DIR/ssl/kafka.truststore.jks" ]; then
+              FILE_SIZE=$(stat -c%s "$APP_DIR/ssl/kafka.truststore.jks")
+              echo "[SSL] ✅ 파일 존재 (크기: ${FILE_SIZE} bytes)"
+              if [ "$FILE_SIZE" -eq 0 ]; then
+                echo "[SSL] ❌ 파일이 비어있음 — base64 디코딩 실패"
+                exit 1
+              fi
+            else
+              echo "[SSL] ❌ 파일 생성 실패"
+              exit 1
+            fi
+
+            echo "[SSL] ssl 디렉토리 내용:"
+            ls -lh $APP_DIR/ssl/
 
             # 새 이미지 pull & 재시작
             COMPOSE_FILE="${{ steps.vars.outputs.compose }}"
-            docker compose -f $COMPOSE_FILE pull $SERVICE
-            docker compose -f $COMPOSE_FILE up -d $SERVICE
+            docker compose --env-file $ENV_FILE -f $COMPOSE_FILE pull $SERVICE
+            docker compose --env-file $ENV_FILE -f $COMPOSE_FILE up -d $SERVICE
 
             # Health check (30초 간격, 최대 8회)
             echo "Health check 시작... (port: ${{ vars.HEALTH_CHECK_PORT }})"

--- a/build.gradle
+++ b/build.gradle
@@ -61,7 +61,7 @@ dependencies {
 	implementation 'io.zipkin.reporter2:zipkin-reporter-brave'
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.16'
 
-	implementation 'com.goggles:common-library:1.0.4'
+	implementation 'com.goggles:common-library:1.0.5'
 
 	testCompileOnly 'org.projectlombok:lombok'
 	testAnnotationProcessor 'org.projectlombok:lombok'

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -16,3 +16,5 @@ services:
       REDIS_SENTINEL_3: ${REDIS_SENTINEL_3}
       REDIS_PASSWORD: ${REDIS_PASSWORD}
       EUREKA_SERVER_URL: ${EUREKA_SERVER_URL}
+    volumes:
+      - ../ssl:/app/ssl:ro

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,4 +4,6 @@ services:
     env_file: .env
     ports:
       - "9006:9006"
+    volumes:
+      - ./ssl/kafka.truststore.jks:/app/ssl/kafka.truststore.jks:ro
     restart: unless-stopped

--- a/src/main/java/com/goggles/mentoring_service/application/command/BookingCommand.java
+++ b/src/main/java/com/goggles/mentoring_service/application/command/BookingCommand.java
@@ -29,4 +29,9 @@ public class BookingCommand {
 
 	public record RescheduleSession(UUID bookingId, UUID sessionId, LocalDate newDate,
 									LocalTime newStartTime, UUID userId, UserType userType) {}
+
+	public record Rollback(UUID bookingId, String cancelReason) {}
+
+	public record Cancellation(UUID bookingId, UUID userId, UserType userType, UUID orderId,
+							   String cancelReason, String cancelDescription) {}
 }

--- a/src/main/java/com/goggles/mentoring_service/application/command/BookingCommand.java
+++ b/src/main/java/com/goggles/mentoring_service/application/command/BookingCommand.java
@@ -14,6 +14,8 @@ public class BookingCommand {
 						 String requestMessage, UUID orderId) {}
 
 
+	public record PaymentCompleted(MentoringBookingId mentoringBookingId, UUID orderId) {}
+
 	public record PaymentFailed(MentoringBookingId mentoringBookingId, UUID orderId,
 								String failureReason) {}
 

--- a/src/main/java/com/goggles/mentoring_service/application/service/BookingService.java
+++ b/src/main/java/com/goggles/mentoring_service/application/service/BookingService.java
@@ -72,6 +72,21 @@ public class BookingService {
 	}
 
 	@Transactional
+	public void confirmCanceledByOrder(UUID bookingId) {
+		bookingRepository.findById(new MentoringBookingId(bookingId)).ifPresent(booking -> {
+			if (booking.getStatus() == BookingStatus.CANCELED) {
+				return;
+			}
+			MentoringId mentoringId = new MentoringId(booking.getBookedMentoring().getMentoringId());
+			mentoringRepository.findById(mentoringId).ifPresent(mentoring ->
+					booking.getBookingSessions().forEach(session ->
+							mentoring.unbookSession(session.getSessionDate(),
+									session.getSessionStartTime())));
+			booking.forceCancel();
+		});
+	}
+
+	@Transactional
 	public void cancelBookingByOrder(BookingCommand.Cancellation command) {
 		MentoringBookingId bookingId = new MentoringBookingId(command.bookingId());
 		MentoringBooking booking = bookingRepository.findById(bookingId)

--- a/src/main/java/com/goggles/mentoring_service/application/service/BookingService.java
+++ b/src/main/java/com/goggles/mentoring_service/application/service/BookingService.java
@@ -82,7 +82,7 @@ public class BookingService {
 					booking.getBookingSessions().forEach(session ->
 							mentoring.unbookSession(session.getSessionDate(),
 									session.getSessionStartTime())));
-			booking.forceCancel();
+			booking.forceCancel("주문 취소", LocalDateTime.now());
 		});
 	}
 

--- a/src/main/java/com/goggles/mentoring_service/application/service/BookingService.java
+++ b/src/main/java/com/goggles/mentoring_service/application/service/BookingService.java
@@ -81,10 +81,20 @@ public class BookingService {
 
 	@Transactional
 	public void paymentFailed(BookingCommand.PaymentFailed command) {
-		MentoringBooking booking = bookingRepository.findById(command.mentoringBookingId())
-				.orElseThrow(() -> new BookingNotFoundException(command.mentoringBookingId()));
-		booking.failPayment(command.failureReason(), LocalDateTime.now(), events);
-		bookingRepository.save(booking);
+		failPaymentWithUnbook(command.mentoringBookingId(), command.failureReason());
+	}
+
+	private void failPaymentWithUnbook(MentoringBookingId bookingId, String reason) {
+		MentoringBooking booking = bookingRepository.findById(bookingId)
+				.orElseThrow(() -> new BookingNotFoundException(bookingId));
+
+		MentoringId mentoringId = new MentoringId(booking.getBookedMentoring().getMentoringId());
+		Mentoring mentoring = mentoringRepository.findById(mentoringId)
+				.orElseThrow(() -> new MentoringNotFoundException(mentoringId));
+
+		booking.failPayment(reason, LocalDateTime.now());
+		booking.getBookingSessions().forEach(session ->
+				mentoring.unbookSession(session.getSessionDate(), session.getSessionStartTime()));
 	}
 
 	@Transactional
@@ -162,11 +172,4 @@ public class BookingService {
 		}
 	}
 
-	@Transactional
-	public void paymentFailed(BookingCommand.PaymentFailed command, BookingEvent events) {
-		MentoringBooking booking = bookingRepository.findById(command.mentoringBookingId())
-				.orElseThrow(() -> new BookingNotFoundException(command.mentoringBookingId()));
-		booking.failPayment(command.failureReason(), LocalDateTime.now(), events);
-		bookingRepository.save(booking);
-	}
 }

--- a/src/main/java/com/goggles/mentoring_service/application/service/BookingService.java
+++ b/src/main/java/com/goggles/mentoring_service/application/service/BookingService.java
@@ -72,6 +72,14 @@ public class BookingService {
 	}
 
 	@Transactional
+	public void paymentCompleted(BookingCommand.PaymentCompleted command) {
+		MentoringBooking booking = bookingRepository.findById(command.mentoringBookingId())
+				.orElseThrow(() -> new BookingNotFoundException(command.mentoringBookingId()));
+		booking.completePayment(events);
+		bookingRepository.save(booking);
+	}
+
+	@Transactional
 	public void paymentFailed(BookingCommand.PaymentFailed command) {
 		MentoringBooking booking = bookingRepository.findById(command.mentoringBookingId())
 				.orElseThrow(() -> new BookingNotFoundException(command.mentoringBookingId()));

--- a/src/main/java/com/goggles/mentoring_service/application/service/BookingService.java
+++ b/src/main/java/com/goggles/mentoring_service/application/service/BookingService.java
@@ -71,6 +71,12 @@ public class BookingService {
 				.map(BookingResult.Summary::from);
 	}
 
+
+	@Transactional
+	public void rollbackBooking(BookingCommand.Rollback command) {
+		failPaymentWithUnbook(new MentoringBookingId(command.bookingId()), command.cancelReason());
+	}
+
 	@Transactional
 	public void paymentCompleted(BookingCommand.PaymentCompleted command) {
 		MentoringBooking booking = bookingRepository.findById(command.mentoringBookingId())

--- a/src/main/java/com/goggles/mentoring_service/application/service/BookingService.java
+++ b/src/main/java/com/goggles/mentoring_service/application/service/BookingService.java
@@ -85,8 +85,6 @@ public class BookingService {
 		MentoringBooking booking = bookingRepository.findById(id)
 				.orElseThrow(() -> new BookingNotFoundException(id));
 		booking.accept(command.userId(), command.userType(), events);
-
-		events.mentoringBookingAccepted(booking);
 	}
 
 	@Transactional
@@ -95,8 +93,6 @@ public class BookingService {
 		MentoringBooking booking = bookingRepository.findById(id)
 				.orElseThrow(() -> new BookingNotFoundException(id));
 		booking.reject(command.userId(), command.userType(), command.reason(), LocalDateTime.now(), events);
-
-		events.mentoringBookingRejected(booking);
 	}
 
 	@Transactional
@@ -105,8 +101,6 @@ public class BookingService {
 		MentoringBooking booking = bookingRepository.findById(id)
 				.orElseThrow(() -> new BookingNotFoundException(id));
 		booking.cancel(command.userId(), command.userType(), command.reason(), LocalDateTime.now(), events);
-
-		events.mentoringBookingCanceled(booking);
 	}
 
 

--- a/src/main/java/com/goggles/mentoring_service/application/service/BookingService.java
+++ b/src/main/java/com/goggles/mentoring_service/application/service/BookingService.java
@@ -71,6 +71,21 @@ public class BookingService {
 				.map(BookingResult.Summary::from);
 	}
 
+	@Transactional
+	public void cancelBookingByOrder(BookingCommand.Cancellation command) {
+		MentoringBookingId bookingId = new MentoringBookingId(command.bookingId());
+		MentoringBooking booking = bookingRepository.findById(bookingId)
+				.orElseThrow(() -> new BookingNotFoundException(bookingId));
+
+		MentoringId mentoringId = new MentoringId(booking.getBookedMentoring().getMentoringId());
+		Mentoring mentoring = mentoringRepository.findById(mentoringId)
+				.orElseThrow(() -> new MentoringNotFoundException(mentoringId));
+
+		booking.cancelByOrder(command.userId(), command.userType(), command.cancelReason(),
+				LocalDateTime.now(), events);
+		booking.getBookingSessions().forEach(session ->
+				mentoring.unbookSession(session.getSessionDate(), session.getSessionStartTime()));
+	}
 
 	@Transactional
 	public void rollbackBooking(BookingCommand.Rollback command) {

--- a/src/main/java/com/goggles/mentoring_service/domain/booking/MentoringBooking.java
+++ b/src/main/java/com/goggles/mentoring_service/domain/booking/MentoringBooking.java
@@ -125,6 +125,11 @@ public class MentoringBooking extends BaseAudit {
 		this.closure = BookingClosure.close(canceledBy, reason, now);
 		events.mentoringBookingCanceled(this);
 	}
+
+	public void forceCancel() {
+		this.status = BookingStatus.CANCELED;
+	}
+
 	public void completeSession(UUID sessionId, UUID userId, UserType userType) {
 		checkIfUserIsMentor(userId, userType);
 		if (status != BookingStatus.ACCEPTED) {

--- a/src/main/java/com/goggles/mentoring_service/domain/booking/MentoringBooking.java
+++ b/src/main/java/com/goggles/mentoring_service/domain/booking/MentoringBooking.java
@@ -62,20 +62,19 @@ public class MentoringBooking extends BaseAudit {
 	public static MentoringBooking create(UUID menteeId, UserType menteeUserType, String menteeName,
 			Mentoring mentoring, List<SessionSlot> sessionSlots, String requestMessage,
 			UUID orderId) {
-		Mentee mentee =  Mentee.of(menteeId, menteeUserType, menteeName);
+		Mentee mentee = Mentee.of(menteeId, menteeUserType, menteeName);
 		List<BookingSession> bookingSessions = new ArrayList<>();
 		for (SessionSlot slot : sessionSlots) {
 			bookingSessions.add(BookingSession.of(slot));
 		}
 		BookedMentoring bookedMentoring = BookedMentoring.of(mentoring);
-		return new MentoringBooking(bookedMentoring, mentee, bookingSessions, requestMessage,
-				orderId);
+		return new MentoringBooking(bookedMentoring, mentee, bookingSessions, requestMessage, orderId);
 	}
 
 	public void completePayment(BookingEvent events) {
 		validateStatus(BookingStatus.PAYMENT_COMPLETED);
 		this.status = BookingStatus.PAYMENT_COMPLETED;
-		events.bookingPaymentCompleted(this);
+		events.bookingRequested(this);
 	}
 
 	public void failPayment(String reason, LocalDateTime now) {
@@ -126,8 +125,9 @@ public class MentoringBooking extends BaseAudit {
 		events.mentoringBookingCanceled(this);
 	}
 
-	public void forceCancel() {
+	public void forceCancel(String reason, LocalDateTime now) {
 		this.status = BookingStatus.CANCELED;
+		this.closure = BookingClosure.close(null, reason, now);
 	}
 
 	public void completeSession(UUID sessionId, UUID userId, UserType userType) {

--- a/src/main/java/com/goggles/mentoring_service/domain/booking/MentoringBooking.java
+++ b/src/main/java/com/goggles/mentoring_service/domain/booking/MentoringBooking.java
@@ -78,11 +78,10 @@ public class MentoringBooking extends BaseAudit {
 		events.bookingPaymentCompleted(this);
 	}
 
-	public void failPayment(String reason, LocalDateTime now, BookingEvent events) {
+	public void failPayment(String reason, LocalDateTime now) {
 		validateStatus(BookingStatus.PAYMENT_FAILED);
 		this.status = BookingStatus.PAYMENT_FAILED;
 		this.closure = BookingClosure.close(this.mentee.getId(), reason, now);
-		events.bookingPaymentFailed(this);
 	}
 
 	public void accept(UUID userId, UserType userType, BookingEvent events) {

--- a/src/main/java/com/goggles/mentoring_service/domain/booking/MentoringBooking.java
+++ b/src/main/java/com/goggles/mentoring_service/domain/booking/MentoringBooking.java
@@ -114,6 +114,17 @@ public class MentoringBooking extends BaseAudit {
 
 	}
 
+	public void cancelByOrder(UUID canceledBy, UserType userType, String reason, LocalDateTime now,
+			BookingEvent events) {
+		if (status != BookingStatus.PAYMENT_COMPLETED && status != BookingStatus.ACCEPTED) {
+			throw InvalidBookingStatusTransitionException.cannotCancelByOrder(this.status);
+		}
+		validateReason(reason);
+		checkIfUserCanCancel(canceledBy, userType);
+		this.status = BookingStatus.CANCELED;
+		this.closure = BookingClosure.close(canceledBy, reason, now);
+		events.mentoringBookingCanceled(this);
+	}
 	public void completeSession(UUID sessionId, UUID userId, UserType userType) {
 		checkIfUserIsMentor(userId, userType);
 		if (status != BookingStatus.ACCEPTED) {

--- a/src/main/java/com/goggles/mentoring_service/domain/booking/MentoringBooking.java
+++ b/src/main/java/com/goggles/mentoring_service/domain/booking/MentoringBooking.java
@@ -126,6 +126,10 @@ public class MentoringBooking extends BaseAudit {
 	}
 
 	public void forceCancel(String reason, LocalDateTime now) {
+		if (status == BookingStatus.CANCELED || status == BookingStatus.REJECTED
+				|| status == BookingStatus.PAYMENT_FAILED) {
+			return;
+		}
 		this.status = BookingStatus.CANCELED;
 		this.closure = BookingClosure.close(null, reason, now);
 	}

--- a/src/main/java/com/goggles/mentoring_service/domain/booking/event/BookingCanceledEvent.java
+++ b/src/main/java/com/goggles/mentoring_service/domain/booking/event/BookingCanceledEvent.java
@@ -1,8 +1,24 @@
 package com.goggles.mentoring_service.domain.booking.event;
 
+import com.goggles.mentoring_service.domain.booking.MentoringBooking;
+
 import java.util.List;
 import java.util.UUID;
 
 public record BookingCanceledEvent(UUID bookingId, UUID canceledBy, UUID menteeId, UUID mentorId,
 								   String title, String reason,
-								   List<BookingSessionSnapshot> sessionSlots, UUID orderId) {}
+								   List<BookingSessionSnapshot> sessionSlots, UUID orderId) {
+
+	public static BookingCanceledEvent from(MentoringBooking booking) {
+		return new BookingCanceledEvent(
+				booking.getMentoringBookingId().bookingId(),
+				booking.getClosedBy(),
+				booking.getMentee().getId(),
+				booking.getBookedMentoring().getMentorId(),
+				booking.getBookedMentoring().getTitle(),
+				booking.getCloseReason(),
+				booking.getBookingSessions().stream().map(BookingSessionSnapshot::from).toList(),
+				booking.getOrderId()
+		);
+	}
+}

--- a/src/main/java/com/goggles/mentoring_service/domain/booking/event/BookingEvent.java
+++ b/src/main/java/com/goggles/mentoring_service/domain/booking/event/BookingEvent.java
@@ -3,13 +3,11 @@ package com.goggles.mentoring_service.domain.booking.event;
 import com.goggles.mentoring_service.domain.booking.MentoringBooking;
 
 public interface BookingEvent {
-	void bookingPaymentCompleted(MentoringBooking mentoringBooking);
-
-	void bookingPaymentFailed(MentoringBooking mentoringBooking);
-
 	void mentoringBookingAccepted(MentoringBooking mentoringBooking);
 
 	void mentoringBookingRejected(MentoringBooking mentoringBooking);
 
 	void mentoringBookingCanceled(MentoringBooking mentoringBooking);
+
+	void bookingRequested(MentoringBooking mentoringBooking);
 }

--- a/src/main/java/com/goggles/mentoring_service/domain/booking/event/BookingPendingApprovalEvent.java
+++ b/src/main/java/com/goggles/mentoring_service/domain/booking/event/BookingPendingApprovalEvent.java
@@ -1,9 +1,0 @@
-package com.goggles.mentoring_service.domain.booking.event;
-
-import java.time.LocalDate;
-import java.time.LocalTime;
-import java.util.UUID;
-
-public record BookingPendingApprovalEvent(UUID bookingId, UUID mentorId, String menteeName,
-										  String title, LocalDate sessionDate,
-										  LocalTime sessionStartTime, LocalTime sessionEndTime) {}

--- a/src/main/java/com/goggles/mentoring_service/domain/booking/event/BookingRejectedEvent.java
+++ b/src/main/java/com/goggles/mentoring_service/domain/booking/event/BookingRejectedEvent.java
@@ -1,8 +1,24 @@
 package com.goggles.mentoring_service.domain.booking.event;
 
+import com.goggles.mentoring_service.domain.booking.MentoringBooking;
+
 import java.util.List;
 import java.util.UUID;
 
 public record BookingRejectedEvent(UUID bookingId, UUID menteeId, UUID mentorId, String mentorName,
 								   String title, String reason,
-								   List<BookingSessionSnapshot> sessionSlots, UUID orderId) {}
+								   List<BookingSessionSnapshot> sessionSlots, UUID orderId) {
+
+	public static BookingRejectedEvent from(MentoringBooking booking) {
+		return new BookingRejectedEvent(
+				booking.getMentoringBookingId().bookingId(),
+				booking.getMentee().getId(),
+				booking.getBookedMentoring().getMentorId(),
+				booking.getBookedMentoring().getMentorName(),
+				booking.getBookedMentoring().getTitle(),
+				booking.getCloseReason(),
+				booking.getBookingSessions().stream().map(BookingSessionSnapshot::from).toList(),
+				booking.getOrderId()
+		);
+	}
+}

--- a/src/main/java/com/goggles/mentoring_service/domain/booking/event/BookingRequestedEvent.java
+++ b/src/main/java/com/goggles/mentoring_service/domain/booking/event/BookingRequestedEvent.java
@@ -1,9 +1,17 @@
 package com.goggles.mentoring_service.domain.booking.event;
 
-import java.time.LocalDate;
-import java.time.LocalTime;
+import com.goggles.mentoring_service.domain.booking.MentoringBooking;
+
 import java.util.UUID;
 
-public record BookingRequestedEvent(UUID bookingId, UUID mentoringId, UUID menteeId, UUID mentorId,
-									String title, LocalDate sessionDate, LocalTime sessionStartTime,
-									LocalTime sessionEndTime) {}
+public record BookingRequestedEvent(UUID bookingId, UUID mentorId, String menteeName, String title) {
+
+	public static BookingRequestedEvent from(MentoringBooking booking) {
+		return new BookingRequestedEvent(
+				booking.getMentoringBookingId().bookingId(),
+				booking.getBookedMentoring().getMentorId(),
+				booking.getMentee().getName(),
+				booking.getBookedMentoring().getTitle()
+		);
+	}
+}

--- a/src/main/java/com/goggles/mentoring_service/domain/booking/exception/InvalidBookingStatusTransitionException.java
+++ b/src/main/java/com/goggles/mentoring_service/domain/booking/exception/InvalidBookingStatusTransitionException.java
@@ -34,4 +34,10 @@ public class InvalidBookingStatusTransitionException extends MentoringValidation
 		return new InvalidBookingStatusTransitionException(
 				String.format("이미 종료된 예약은 변경할 수 없습니다. 현재 상태: %s", current));
 	}
+
+	public static InvalidBookingStatusTransitionException cannotCancelByOrder(BookingStatus current) {
+		return new InvalidBookingStatusTransitionException(
+				String.format("주문 취소는 PAYMENT_COMPLETED 또는 ACCEPTED 상태에서만 가능합니다. 현재 상태: %s",
+						current));
+	}
 }

--- a/src/main/java/com/goggles/mentoring_service/infrastructure/config/EventInfraConfig.java
+++ b/src/main/java/com/goggles/mentoring_service/infrastructure/config/EventInfraConfig.java
@@ -1,9 +1,12 @@
 package com.goggles.mentoring_service.infrastructure.config;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.goggles.common.domain.InboxRepository;
 import com.goggles.common.domain.OutboxRepository;
 import com.goggles.common.event.OutboxEventListener;
 import com.goggles.common.event.OutboxStatusUpdater;
+import com.goggles.common.event.advice.InboxAdvice;
+import com.goggles.common.event.scheduler.InboxCleanupScheduler;
 import com.goggles.common.event.scheduler.OutboxRelayScheduler;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.context.annotation.Bean;
@@ -36,5 +39,17 @@ public class EventInfraConfig {
 	public OutboxRelayScheduler outboxRelayScheduler(OutboxRepository outboxRepository,
 			KafkaTemplate<String, Object> kafkaTemplate, OutboxStatusUpdater outboxStatusUpdater) {
 		return new OutboxRelayScheduler(outboxRepository, kafkaTemplate, outboxStatusUpdater);
+	}
+
+	@Bean
+	@ConditionalOnBean(KafkaTemplate.class)
+	public InboxAdvice inboxAdvice(InboxRepository inboxRepository) {
+		return new InboxAdvice(inboxRepository);
+	}
+
+	@Bean
+	@ConditionalOnBean(KafkaTemplate.class)
+	public InboxCleanupScheduler inboxCleanupScheduler(InboxRepository inboxRepository) {
+		return new InboxCleanupScheduler(inboxRepository);
 	}
 }

--- a/src/main/java/com/goggles/mentoring_service/infrastructure/config/KafkaTopicProperties.java
+++ b/src/main/java/com/goggles/mentoring_service/infrastructure/config/KafkaTopicProperties.java
@@ -3,7 +3,7 @@ package com.goggles.mentoring_service.infrastructure.config;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
 @ConfigurationProperties(prefix = "kafka.topics")
-public record KafkaTopicProperties(Booking booking) {
+public record KafkaTopicProperties(Booking booking, Order order) {
 
 	public record Booking(
 			String paymentCompleted,
@@ -14,4 +14,6 @@ public record KafkaTopicProperties(Booking booking) {
 			String requested,
 			String pendingApproval
 	) {}
+
+	public record Order(String mentoringCompleted, String mentoringCanceled) {}
 }

--- a/src/main/java/com/goggles/mentoring_service/infrastructure/consumer/OrderMentoringCanceledConsumer.java
+++ b/src/main/java/com/goggles/mentoring_service/infrastructure/consumer/OrderMentoringCanceledConsumer.java
@@ -1,0 +1,36 @@
+package com.goggles.mentoring_service.infrastructure.consumer;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.goggles.common.event.annotation.IdempotentConsumer;
+import com.goggles.mentoring_service.application.service.BookingService;
+import com.goggles.mentoring_service.infrastructure.consumer.event.OrderMentoringCanceledEvent;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class OrderMentoringCanceledConsumer {
+
+	private final BookingService bookingService;
+	private final ObjectMapper objectMapper;
+
+	@KafkaListener(topics = "${kafka.topics.order.mentoring-canceled}",
+			groupId = "${spring.kafka.consumer.group-id}")
+	@IdempotentConsumer("ORDER_MENTORING_CANCELED")
+	public void consume(ConsumerRecord<String, String> record) {
+		try {
+			OrderMentoringCanceledEvent event =
+					objectMapper.readValue(record.value(), OrderMentoringCanceledEvent.class);
+
+			bookingService.confirmCanceledByOrder(event.enrollmentId());
+		} catch (Exception e) {
+			log.error("멘토링 주문 취소 이벤트 처리 실패. offset={}, value={}", record.offset(),
+					record.value(), e);
+			throw new RuntimeException(e);
+		}
+	}
+}

--- a/src/main/java/com/goggles/mentoring_service/infrastructure/consumer/OrderMentoringCompletedConsumer.java
+++ b/src/main/java/com/goggles/mentoring_service/infrastructure/consumer/OrderMentoringCompletedConsumer.java
@@ -1,0 +1,41 @@
+package com.goggles.mentoring_service.infrastructure.consumer;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.goggles.common.event.annotation.IdempotentConsumer;
+import com.goggles.mentoring_service.application.command.BookingCommand;
+import com.goggles.mentoring_service.application.service.BookingService;
+import com.goggles.mentoring_service.domain.booking.MentoringBookingId;
+import com.goggles.mentoring_service.infrastructure.consumer.event.OrderMentoringCompletedEvent;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class OrderMentoringCompletedConsumer {
+
+	private final BookingService bookingService;
+	private final ObjectMapper objectMapper;
+
+	@KafkaListener(topics = "${kafka.topics.order.mentoring-completed}",
+			groupId = "${spring.kafka.consumer.group-id}")
+	@IdempotentConsumer("ORDER_MENTORING_COMPLETED")
+	public void consume(ConsumerRecord<String, String> record) {
+		try {
+			OrderMentoringCompletedEvent event =
+					objectMapper.readValue(record.value(), OrderMentoringCompletedEvent.class);
+
+			BookingCommand.PaymentCompleted command = new BookingCommand.PaymentCompleted(
+					new MentoringBookingId(event.enrollmentId()), event.orderId());
+
+			bookingService.paymentCompleted(command);
+		} catch (Exception e) {
+			log.error("멘토링 주문 완료 이벤트 처리 실패. offset={}, value={}", record.offset(),
+					record.value(), e);
+			throw new RuntimeException(e);
+		}
+	}
+}

--- a/src/main/java/com/goggles/mentoring_service/infrastructure/consumer/event/OrderMentoringCanceledEvent.java
+++ b/src/main/java/com/goggles/mentoring_service/infrastructure/consumer/event/OrderMentoringCanceledEvent.java
@@ -1,0 +1,5 @@
+package com.goggles.mentoring_service.infrastructure.consumer.event;
+
+import java.util.UUID;
+
+public record OrderMentoringCanceledEvent(UUID orderId, UUID userId, UUID enrollmentId) {}

--- a/src/main/java/com/goggles/mentoring_service/infrastructure/consumer/event/OrderMentoringCompletedEvent.java
+++ b/src/main/java/com/goggles/mentoring_service/infrastructure/consumer/event/OrderMentoringCompletedEvent.java
@@ -1,0 +1,5 @@
+package com.goggles.mentoring_service.infrastructure.consumer.event;
+
+import java.util.UUID;
+
+public record OrderMentoringCompletedEvent(UUID orderId, UUID userId, UUID enrollmentId) {}

--- a/src/main/java/com/goggles/mentoring_service/infrastructure/event/BookingEventImpl.java
+++ b/src/main/java/com/goggles/mentoring_service/infrastructure/event/BookingEventImpl.java
@@ -6,8 +6,7 @@ import com.goggles.mentoring_service.domain.booking.event.BookingAcceptedEvent;
 import com.goggles.mentoring_service.domain.booking.event.BookingCanceledEvent;
 import com.goggles.mentoring_service.domain.booking.event.BookingEvent;
 import com.goggles.mentoring_service.domain.booking.event.BookingRejectedEvent;
-import com.goggles.mentoring_service.domain.booking.event.PaymentCompletedEvent;
-import com.goggles.mentoring_service.domain.booking.event.PaymentFailedEvent;
+import com.goggles.mentoring_service.domain.booking.event.BookingRequestedEvent;
 import com.goggles.mentoring_service.infrastructure.config.KafkaTopicProperties;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
@@ -19,22 +18,6 @@ import java.util.UUID;
 public class BookingEventImpl implements BookingEvent {
 	private final Events events;
 	private final KafkaTopicProperties kafkaTopicProperties;
-
-	@Override
-	public void bookingPaymentCompleted(MentoringBooking mentoringBooking) {
-		UUID bookingId = mentoringBooking.getMentoringBookingId()
-				.bookingId();
-		events.trigger(bookingId.toString(), "MENTORING_BOOKING",
-				kafkaTopicProperties.booking().paymentCompleted(), new PaymentCompletedEvent(bookingId));
-	}
-
-	@Override
-	public void bookingPaymentFailed(MentoringBooking mentoringBooking) {
-		UUID bookingId = mentoringBooking.getMentoringBookingId()
-				.bookingId();
-		events.trigger(bookingId.toString(), "MENTORING_BOOKING",
-				kafkaTopicProperties.booking().paymentFailed(), new PaymentFailedEvent(bookingId));
-	}
 
 	@Override
 	public void mentoringBookingAccepted(MentoringBooking mentoringBooking) {
@@ -56,5 +39,12 @@ public class BookingEventImpl implements BookingEvent {
 		UUID bookingId = mentoringBooking.getMentoringBookingId().bookingId();
 		events.trigger(bookingId.toString(), "MENTORING_BOOKING",
 				kafkaTopicProperties.booking().canceled(), BookingCanceledEvent.from(mentoringBooking));
+	}
+
+	@Override
+	public void bookingRequested(MentoringBooking mentoringBooking) {
+		UUID bookingId = mentoringBooking.getMentoringBookingId().bookingId();
+		events.trigger(bookingId.toString(), "MENTORING_BOOKING",
+				kafkaTopicProperties.booking().requested(), BookingRequestedEvent.from(mentoringBooking));
 	}
 }

--- a/src/main/java/com/goggles/mentoring_service/infrastructure/event/BookingEventImpl.java
+++ b/src/main/java/com/goggles/mentoring_service/infrastructure/event/BookingEventImpl.java
@@ -3,7 +3,9 @@ package com.goggles.mentoring_service.infrastructure.event;
 import com.goggles.common.event.Events;
 import com.goggles.mentoring_service.domain.booking.MentoringBooking;
 import com.goggles.mentoring_service.domain.booking.event.BookingAcceptedEvent;
+import com.goggles.mentoring_service.domain.booking.event.BookingCanceledEvent;
 import com.goggles.mentoring_service.domain.booking.event.BookingEvent;
+import com.goggles.mentoring_service.domain.booking.event.BookingRejectedEvent;
 import com.goggles.mentoring_service.domain.booking.event.PaymentCompletedEvent;
 import com.goggles.mentoring_service.domain.booking.event.PaymentFailedEvent;
 import com.goggles.mentoring_service.infrastructure.config.KafkaTopicProperties;
@@ -44,11 +46,15 @@ public class BookingEventImpl implements BookingEvent {
 
 	@Override
 	public void mentoringBookingRejected(MentoringBooking mentoringBooking) {
-
+		UUID bookingId = mentoringBooking.getMentoringBookingId().bookingId();
+		events.trigger(bookingId.toString(), "MENTORING_BOOKING",
+				kafkaTopicProperties.booking().rejected(), BookingRejectedEvent.from(mentoringBooking));
 	}
 
 	@Override
 	public void mentoringBookingCanceled(MentoringBooking mentoringBooking) {
-
+		UUID bookingId = mentoringBooking.getMentoringBookingId().bookingId();
+		events.trigger(bookingId.toString(), "MENTORING_BOOKING",
+				kafkaTopicProperties.booking().canceled(), BookingCanceledEvent.from(mentoringBooking));
 	}
 }

--- a/src/main/java/com/goggles/mentoring_service/infrastructure/persistence/jpa/InboxJpaRepository.java
+++ b/src/main/java/com/goggles/mentoring_service/infrastructure/persistence/jpa/InboxJpaRepository.java
@@ -1,0 +1,7 @@
+package com.goggles.mentoring_service.infrastructure.persistence.jpa;
+
+import com.goggles.common.domain.InboxRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface InboxJpaRepository extends InboxRepository {}

--- a/src/main/java/com/goggles/mentoring_service/infrastructure/persistence/jpa/OutboxJpaRepository.java
+++ b/src/main/java/com/goggles/mentoring_service/infrastructure/persistence/jpa/OutboxJpaRepository.java
@@ -4,6 +4,7 @@ import com.goggles.common.domain.Outbox;
 import com.goggles.common.domain.OutboxRepository;
 import com.goggles.common.domain.OutboxStatus;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.time.LocalDateTime;
@@ -15,5 +16,5 @@ public interface OutboxJpaRepository extends OutboxRepository {
 	@Override
 	@Query(value = "SELECT * FROM p_outbox WHERE status = :#{#status.name()} AND updated_at < :threshold",
 			nativeQuery = true)
-	List<Outbox> findByStatusAndUpdatedAtBefore(OutboxStatus status, LocalDateTime threshold);
+	List<Outbox> findByStatusAndUpdatedAtBefore(@Param("status") OutboxStatus status, @Param("threshold") LocalDateTime threshold);
 }

--- a/src/main/java/com/goggles/mentoring_service/infrastructure/persistence/jpa/OutboxJpaRepository.java
+++ b/src/main/java/com/goggles/mentoring_service/infrastructure/persistence/jpa/OutboxJpaRepository.java
@@ -1,7 +1,19 @@
 package com.goggles.mentoring_service.infrastructure.persistence.jpa;
 
+import com.goggles.common.domain.Outbox;
 import com.goggles.common.domain.OutboxRepository;
+import com.goggles.common.domain.OutboxStatus;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
+import java.time.LocalDateTime;
+import java.util.List;
+
 @Repository
-public interface OutboxJpaRepository extends OutboxRepository {}
+public interface OutboxJpaRepository extends OutboxRepository {
+
+	@Override
+	@Query(value = "SELECT * FROM p_outbox WHERE status = :#{#status.name()} AND updated_at < :threshold",
+			nativeQuery = true)
+	List<Outbox> findByStatusAndUpdatedAtBefore(OutboxStatus status, LocalDateTime threshold);
+}

--- a/src/main/java/com/goggles/mentoring_service/presentation/InternalMentoringController.java
+++ b/src/main/java/com/goggles/mentoring_service/presentation/InternalMentoringController.java
@@ -34,6 +34,15 @@ public class InternalMentoringController {
 			@Valid @RequestBody BookingRequest.Rollback request) {
 		bookingService.rollbackBooking(request.toCommand(bookingId));
 	}
+
+	@PatchMapping("mentoring-booking/{bookingId}/cancellation")
+	public void cancelMentoringBooking(@PathVariable UUID bookingId,
+			@RequestHeader("X-User-Id") UUID userId,
+			@RequestHeader("X-User-Role") UserType userType,
+			@Valid @RequestBody BookingRequest.Cancellation request) {
+		bookingService.cancelBookingByOrder(request.toCommand(bookingId, userId, userType));
+	}
+
 	@PatchMapping("mentoring-booking/payment-completed")
 	public void processMentoringBookingPaymentCompleted(
 			@Valid @RequestBody BookingRequest.PaymentCompleted request) {

--- a/src/main/java/com/goggles/mentoring_service/presentation/InternalMentoringController.java
+++ b/src/main/java/com/goggles/mentoring_service/presentation/InternalMentoringController.java
@@ -26,6 +26,12 @@ public class InternalMentoringController {
 		return BookingResponse.Create.of(result);
 	}
 
+	@PatchMapping("mentoring-booking/payment-completed")
+	public void processMentoringBookingPaymentCompleted(
+			@Valid @RequestBody BookingRequest.PaymentCompleted request) {
+		bookingService.paymentCompleted(request.toCommand());
+	}
+
 	@PatchMapping("mentoring-booking/payment-failed")
 	public void processMentoringBookingPaymentFailed(
 			@Valid @RequestBody BookingRequest.PaymentFailed request) {

--- a/src/main/java/com/goggles/mentoring_service/presentation/InternalMentoringController.java
+++ b/src/main/java/com/goggles/mentoring_service/presentation/InternalMentoringController.java
@@ -3,6 +3,7 @@ package com.goggles.mentoring_service.presentation;
 import com.goggles.mentoring_service.application.command.BookingCommand;
 import com.goggles.mentoring_service.application.result.BookingResult;
 import com.goggles.mentoring_service.application.service.BookingService;
+import com.goggles.mentoring_service.domain._common.UserType;
 import com.goggles.mentoring_service.presentation.dto.BookingRequest;
 import com.goggles.mentoring_service.presentation.dto.BookingResponse;
 import com.goggles.mentoring_service.presentation.support.UserContext;
@@ -10,6 +11,8 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.UUID;
 
 @RestController
 @RequestMapping("/internal/v1/")
@@ -26,6 +29,11 @@ public class InternalMentoringController {
 		return BookingResponse.Create.of(result);
 	}
 
+	@PatchMapping("mentoring-booking/{bookingId}/rollback")
+	public void rollbackMentoringBooking(@PathVariable UUID bookingId,
+			@Valid @RequestBody BookingRequest.Rollback request) {
+		bookingService.rollbackBooking(request.toCommand(bookingId));
+	}
 	@PatchMapping("mentoring-booking/payment-completed")
 	public void processMentoringBookingPaymentCompleted(
 			@Valid @RequestBody BookingRequest.PaymentCompleted request) {

--- a/src/main/java/com/goggles/mentoring_service/presentation/dto/BookingRequest.java
+++ b/src/main/java/com/goggles/mentoring_service/presentation/dto/BookingRequest.java
@@ -37,6 +37,12 @@ public class BookingRequest {
 		}
 	}
 
+	public record PaymentCompleted(@NotNull UUID mentoringBookingId, @NotNull UUID orderId) {
+		public BookingCommand.PaymentCompleted toCommand() {
+			return new BookingCommand.PaymentCompleted(new MentoringBookingId(mentoringBookingId()), orderId());
+		}
+	}
+
 	public record PaymentFailed(@NotNull UUID mentoringBookingId, @NotNull UUID orderId,
 								@NotNull String failureReason) {
 		public BookingCommand.PaymentFailed toCommand() {

--- a/src/main/java/com/goggles/mentoring_service/presentation/dto/BookingRequest.java
+++ b/src/main/java/com/goggles/mentoring_service/presentation/dto/BookingRequest.java
@@ -70,4 +70,12 @@ public class BookingRequest {
 			return new BookingCommand.Rollback(bookingId, cancelReason());
 		}
 	}
+
+	public record Cancellation(@NotNull UUID orderId, @NotBlank String cancelReason,
+							   String cancelDescription) {
+		public BookingCommand.Cancellation toCommand(UUID bookingId, UUID userId, UserType userType) {
+			return new BookingCommand.Cancellation(bookingId, userId, userType, orderId(),
+					cancelReason(), cancelDescription());
+		}
+	}
 }

--- a/src/main/java/com/goggles/mentoring_service/presentation/dto/BookingRequest.java
+++ b/src/main/java/com/goggles/mentoring_service/presentation/dto/BookingRequest.java
@@ -2,6 +2,7 @@ package com.goggles.mentoring_service.presentation.dto;
 
 import com.goggles.mentoring_service.application.command.BookingCommand;
 import com.goggles.mentoring_service.application.command.MenteeInfo;
+import com.goggles.mentoring_service.domain._common.UserType;
 import com.goggles.mentoring_service.domain.booking.MentoringBookingId;
 import com.goggles.mentoring_service.domain.booking.SessionSlot;
 import com.goggles.mentoring_service.presentation.support.UserContext;
@@ -63,4 +64,10 @@ public class BookingRequest {
 
 
 	public record RescheduleSession(@NotNull LocalDate newDate, @NotNull LocalTime newStartTime) {}
+
+	public record Rollback(@NotBlank String cancelReason) {
+		public BookingCommand.Rollback toCommand(UUID bookingId) {
+			return new BookingCommand.Rollback(bookingId, cancelReason());
+		}
+	}
 }

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -2,7 +2,7 @@ spring:
   application:
     name: mentoring-service
   profiles:
-    active: ${SPRING_PROFILES_ACTIVE:local}
+    active: ${SPRING_PROFILES_ACTIVE:local},topics
   config:
     import:
       - "optional:configserver: "
@@ -36,6 +36,11 @@ spring:
     producer:
       key-serializer: org.apache.kafka.common.serialization.StringSerializer
       value-serializer: org.apache.kafka.common.serialization.StringSerializer
+    consumer:
+      group-id: mentoring-service
+      auto-offset-reset: earliest
+      key-deserializer: org.apache.kafka.common.serialization.StringDeserializer
+      value-deserializer: org.apache.kafka.common.serialization.StringDeserializer
 
 kafka:
   topics:
@@ -47,6 +52,9 @@ kafka:
       canceled: mentoring.booking.canceled.v1
       requested: mentoring.booking.requested.v1
       pending-approval: mentoring.booking.pending_approval.v1
+    order:
+      mentoring-completed: ${topics.order.mentoring-completed:order.mentoring-completed.v1}
+      mentoring-canceled: ${topics.order.mentoring-cancelled:order.mentoring-canceled.v1}
 
 resilience4j:
   circuitbreaker:

--- a/src/test/java/com/goggles/mentoring_service/domain/booking/MentoringBookingTest.java
+++ b/src/test/java/com/goggles/mentoring_service/domain/booking/MentoringBookingTest.java
@@ -15,6 +15,7 @@ import static com.goggles.mentoring_service.domain.mentoring.MentoringFixture.ME
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 
 class MentoringBookingTest {
 
@@ -44,7 +45,7 @@ class MentoringBookingTest {
 		assertThatThrownBy(
 				() -> MentoringBooking.create(instructorId, UserType.INSTRUCTOR, "이강사", mentoring(),
 						List.of(sessionSlot()), REQUEST_MESSAGE, UUID.randomUUID())).isInstanceOf(
-				RuntimeException.class);
+					RuntimeException.class);
 	}
 
 	@Test
@@ -56,11 +57,23 @@ class MentoringBookingTest {
 	}
 
 	@Test
+	void completePayment_publishes_booking_requested_event() {
+		MentoringBooking booking = pendingBooking();
+		booking.completePayment(events);
+
+		verify(events).bookingRequested(booking);
+	}
+
+	@Test
 	void failPayment_success() {
 		MentoringBooking booking = pendingBooking();
-		booking.failPayment("결제 실패 사유", LocalDateTime.now(), events);
+		LocalDateTime now = LocalDateTime.of(2026, 6, 1, 12, 0);
+
+		booking.failPayment("카드 한도 초과", now);
 
 		assertThat(booking.getStatus()).isEqualTo(BookingStatus.PAYMENT_FAILED);
+		assertThat(booking.getCloseReason()).isEqualTo("카드 한도 초과");
+		assertThat(booking.getClosedAt()).isEqualTo(now);
 	}
 
 
@@ -214,7 +227,7 @@ class MentoringBookingTest {
 		assertThatThrownBy(
 				() -> MentoringBooking.create(MENTOR_ID, UserType.INSTRUCTOR, "이강사", mentoring(),
 						List.of(sessionSlot()), REQUEST_MESSAGE, UUID.randomUUID())).isInstanceOf(
-				RuntimeException.class);
+					RuntimeException.class);
 	}
 
 
@@ -335,9 +348,84 @@ class MentoringBookingTest {
 	@Test
 	void cancel_from_payment_failed() {
 		MentoringBooking booking = pendingBooking();
-		booking.failPayment("결제 실패 사유", LocalDateTime.now(), events);
+		booking.failPayment("결제 실패 사유", LocalDateTime.now());
 
 		assertThatThrownBy(() -> booking.cancel(MENTEE_ID, UserType.STUDENT, CANCEL_REASON,
 				BEFORE_DEADLINE,events)).isInstanceOf(InvalidBookingStatusTransitionException.class);
+	}
+
+	// ── cancelByOrder ─────────────────────────────────────────────────────────
+
+	@Test
+	void cancelByOrder_from_payment_completed_by_mentee() {
+		MentoringBooking booking = paymentCompletedBooking();
+
+		booking.cancelByOrder(MENTEE_ID, UserType.STUDENT, "사용자 취소", LocalDateTime.now(), events);
+
+		assertThat(booking.getStatus()).isEqualTo(BookingStatus.CANCELED);
+		assertThat(booking.getClosedBy()).isEqualTo(MENTEE_ID);
+		assertThat(booking.getCloseReason()).isEqualTo("사용자 취소");
+	}
+
+	@Test
+	void cancelByOrder_from_accepted_by_mentor() {
+		MentoringBooking booking = acceptedBooking();
+
+		booking.cancelByOrder(MENTOR_ID, UserType.INSTRUCTOR, "멘토 취소", LocalDateTime.now(), events);
+
+		assertThat(booking.getStatus()).isEqualTo(BookingStatus.CANCELED);
+		assertThat(booking.getClosedBy()).isEqualTo(MENTOR_ID);
+	}
+
+	@Test
+	void cancelByOrder_from_pending_fails() {
+		MentoringBooking booking = pendingBooking();
+
+		assertThatThrownBy(
+				() -> booking.cancelByOrder(MENTEE_ID, UserType.STUDENT, "취소", LocalDateTime.now(),
+						events)).isInstanceOf(InvalidBookingStatusTransitionException.class);
+	}
+
+	@Test
+	void cancelByOrder_without_reason_fails() {
+		MentoringBooking booking = paymentCompletedBooking();
+
+		assertThatThrownBy(
+				() -> booking.cancelByOrder(MENTEE_ID, UserType.STUDENT, "", LocalDateTime.now(),
+						events)).isInstanceOf(CancellationReasonRequiredException.class);
+	}
+
+	@Test
+	void cancelByOrder_by_unauthorized_user_fails() {
+		MentoringBooking booking = paymentCompletedBooking();
+
+		assertThatThrownBy(
+				() -> booking.cancelByOrder(UUID.randomUUID(), UserType.STUDENT, "취소",
+						LocalDateTime.now(), events)).isInstanceOf(
+				UnauthorizedBookingAccessException.class);
+	}
+
+	// ── forceCancel ───────────────────────────────────────────────────────────
+
+	@Test
+	void forceCancel_sets_status_and_closure() {
+		MentoringBooking booking = paymentCompletedBooking();
+		LocalDateTime now = LocalDateTime.of(2026, 6, 1, 12, 0);
+
+		booking.forceCancel("주문 취소", now);
+
+		assertThat(booking.getStatus()).isEqualTo(BookingStatus.CANCELED);
+		assertThat(booking.getCloseReason()).isEqualTo("주문 취소");
+		assertThat(booking.getClosedAt()).isEqualTo(now);
+		assertThat(booking.getClosedBy()).isNull();
+	}
+
+	@Test
+	void forceCancel_from_accepted() {
+		MentoringBooking booking = acceptedBooking();
+
+		booking.forceCancel("주문 취소", LocalDateTime.now());
+
+		assertThat(booking.getStatus()).isEqualTo(BookingStatus.CANCELED);
 	}
 }


### PR DESCRIPTION
### 📌 관련 이슈
- close #32 
### 💡 작업 내용
  - rollback/cancellation internal api   
  - order event Kafka consumer          
  -  발행 이벤트 재편                                             
  - rollback/cancel-pending 처리 통합 
  
  ### 🔍 변경 이유                                                                                             
  - order-service 연동에 필요한 엔드포인트 및 Kafka consumer 미구현 상태였음                                   
  - 이벤트 구조가 모호하고 rollback/결제 실패 간 처리 불일치 존재                                              
                                                                                                               
  ### 📝 리뷰 포인트                                                                                                                         
  - `forceCancel()` closedBy null 처리 방식                                                                    
                                                                                                               
  ### 🧠 기타 참고 사항                                                                                        

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **인프라 개선**
  * 보안 강화된 클라우드 배포 인증으로 전환
  * 환경별(개발/운영) 배포 설정 분리 추가

* **기능 개선**
  * 멘토링 예약 취소 및 결제 처리 흐름 개선
  * 주문 기반 멘토링 예약 관리 기능 추가

* **안정성 개선**
  * 이벤트 처리 인프라 강화 (Kafka 기반 메시지 동기화)
  * 배포 상태 확인 및 자동 복구 메커니즘 개선

<!-- end of auto-generated comment: release notes by coderabbit.ai -->