### PR TITLE
[Feat] scheduler 기능 구현

### DIFF
--- a/src/main/java/com/goggles/mentoring_service/application/service/BookingService.java
+++ b/src/main/java/com/goggles/mentoring_service/application/service/BookingService.java
@@ -193,6 +193,21 @@ public class BookingService {
 		mentoring.bookSession(command.newDate(), command.newStartTime());
 	}
 
+	@Transactional
+	public int autoCancelUnapproved(LocalDateTime threshold) {
+		List<MentoringBooking> bookings = bookingRepository.findPaymentCompletedWithApproachingSessions(
+				threshold.toLocalDate(), threshold.toLocalTime());
+		for (MentoringBooking booking : bookings) {
+			MentoringId mentoringId = new MentoringId(booking.getBookedMentoring().getMentoringId());
+			mentoringRepository.findById(mentoringId).ifPresent(mentoring ->
+					booking.getBookingSessions().forEach(session ->
+							mentoring.unbookSession(session.getSessionDate(),
+									session.getSessionStartTime())));
+			booking.forceCancel("멘토 미승인으로 인한 자동 취소", LocalDateTime.now());
+		}
+		return bookings.size();
+	}
+
 	private MentoringBooking findBooking(UUID bookingId) {
 		return bookingRepository.findById(new MentoringBookingId(bookingId))
 				.orElseThrow(() -> new BookingNotFoundException(new MentoringBookingId(bookingId)));

--- a/src/main/java/com/goggles/mentoring_service/application/service/MentoringService.java
+++ b/src/main/java/com/goggles/mentoring_service/application/service/MentoringService.java
@@ -9,10 +9,7 @@ import com.goggles.mentoring_service.domain.category.MentoringCategory;
 import com.goggles.mentoring_service.domain.category.MentoringCategoryId;
 import com.goggles.mentoring_service.domain.category.exception.CategoryNotFoundException;
 import com.goggles.mentoring_service.domain.category.repository.MentoringCategoryRepository;
-import com.goggles.mentoring_service.domain.mentoring.Mentoring;
-import com.goggles.mentoring_service.domain.mentoring.MentoringId;
-import com.goggles.mentoring_service.domain.mentoring.MentoringSearchCondition;
-import com.goggles.mentoring_service.domain.mentoring.RepeatPattern;
+import com.goggles.mentoring_service.domain.mentoring.*;
 import com.goggles.mentoring_service.domain.mentoring.exception.MentoringNotFoundException;
 import com.goggles.mentoring_service.domain.mentoring.repository.MentoringRepository;
 import lombok.RequiredArgsConstructor;
@@ -32,6 +29,7 @@ public class MentoringService {
 
 	private final MentoringRepository mentoringRepository;
 	private final MentoringCategoryRepository categoryRepository;
+	private final HolidayProvider holidayProvider;
 
 	public UUID createMentoring(MentoringCommand.Create command) {
 		UUID categoryId = command.categoryId();
@@ -87,6 +85,15 @@ public class MentoringService {
 		mentoring.delete(userId, userType);
 	}
 
+	@Transactional
+	public void generateDailyRepeatSessions(LocalDate targetDate) {
+		List<Mentoring> mentorings = mentoringRepository.findActiveWithRepeatPatterns();
+		for (Mentoring mentoring : mentorings) {
+			List<MentoringSession> candidates =
+					mentoring.generateSessions(targetDate, targetDate, holidayProvider);
+			mentoring.addSessionsIfAbsent(candidates);
+		}
+	}
 	private Mentoring getOrThrow(UUID mentoringId) {
 		MentoringId id = new MentoringId(mentoringId);
 		return mentoringRepository.findById(id)

--- a/src/main/java/com/goggles/mentoring_service/application/service/MentoringService.java
+++ b/src/main/java/com/goggles/mentoring_service/application/service/MentoringService.java
@@ -94,6 +94,13 @@ public class MentoringService {
 			mentoring.addSessionsIfAbsent(candidates);
 		}
 	}
+
+	@Transactional
+	public void cleanupExpiredSessions(LocalDate today) {
+		List<Mentoring> mentorings = mentoringRepository.findWithExpiredNonBookedSessions(today);
+		mentorings.forEach(mentoring -> mentoring.cleanupPastSessions(today));
+	}
+
 	private Mentoring getOrThrow(UUID mentoringId) {
 		MentoringId id = new MentoringId(mentoringId);
 		return mentoringRepository.findById(id)

--- a/src/main/java/com/goggles/mentoring_service/domain/booking/repository/MentoringBookingRepository.java
+++ b/src/main/java/com/goggles/mentoring_service/domain/booking/repository/MentoringBookingRepository.java
@@ -6,6 +6,9 @@ import com.goggles.mentoring_service.domain.booking.MentoringBookingId;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.util.List;
 import java.util.Optional;
 
 public interface MentoringBookingRepository {
@@ -15,4 +18,6 @@ public interface MentoringBookingRepository {
 	Optional<MentoringBooking> findById(MentoringBookingId id);
 
 	Page<MentoringBooking> findByUser(BookingSearchCondition condition, Pageable pageable);
+
+	List<MentoringBooking> findPaymentCompletedWithApproachingSessions(LocalDate thresholdDate, LocalTime thresholdTime);
 }

--- a/src/main/java/com/goggles/mentoring_service/domain/mentoring/Mentoring.java
+++ b/src/main/java/com/goggles/mentoring_service/domain/mentoring/Mentoring.java
@@ -331,4 +331,18 @@ public class Mentoring extends BaseAudit {
 		findSession(date, startTime).unbook();
 	}
 
+
+	public void addSessionsIfAbsent(List<MentoringSession> candidates) {
+		Set<LocalDateTime> existing = sessions.stream()
+				.map(session -> LocalDateTime.of(session.getSessionDate(), session.getSessionStartTime()))
+				.collect(Collectors.toSet());
+		List<MentoringSession> toAdd = candidates.stream()
+				.filter(session -> !existing.contains(
+						LocalDateTime.of(session.getSessionDate(), session.getSessionStartTime())))
+				.toList();
+		if (!toAdd.isEmpty()) {
+			addSessions(toAdd);
+		}
+	}
+
 }

--- a/src/main/java/com/goggles/mentoring_service/domain/mentoring/Mentoring.java
+++ b/src/main/java/com/goggles/mentoring_service/domain/mentoring/Mentoring.java
@@ -340,7 +340,7 @@ public class Mentoring extends BaseAudit {
 				.map(session -> LocalDateTime.of(session.getSessionDate(), session.getSessionStartTime()))
 				.collect(Collectors.toSet());
 		List<MentoringSession> toAdd = candidates.stream()
-				.filter(session -> !existing.contains(
+				.filter(session -> existing.add(
 						LocalDateTime.of(session.getSessionDate(), session.getSessionStartTime())))
 				.toList();
 		if (!toAdd.isEmpty()) {

--- a/src/main/java/com/goggles/mentoring_service/domain/mentoring/Mentoring.java
+++ b/src/main/java/com/goggles/mentoring_service/domain/mentoring/Mentoring.java
@@ -235,11 +235,11 @@ public class Mentoring extends BaseAudit {
 	public void addSessionsExcludingBooked(List<MentoringSession> candidates) {
 		Set<LocalDateTime> bookedSlots = sessions.stream()
 				.filter(MentoringSession::isBooked)
-				.map(s -> LocalDateTime.of(s.getSessionDate(), s.getSessionStartTime()))
+				.map(session -> LocalDateTime.of(session.getSessionDate(), session.getSessionStartTime()))
 				.collect(Collectors.toSet());
 		List<MentoringSession> filtered = candidates.stream()
-				.filter(s -> !bookedSlots.contains(
-						LocalDateTime.of(s.getSessionDate(), s.getSessionStartTime())))
+				.filter(session -> !bookedSlots.contains(
+						LocalDateTime.of(session.getSessionDate(), session.getSessionStartTime())))
 				.toList();
 		addSessions(filtered);
 	}

--- a/src/main/java/com/goggles/mentoring_service/domain/mentoring/Mentoring.java
+++ b/src/main/java/com/goggles/mentoring_service/domain/mentoring/Mentoring.java
@@ -331,6 +331,9 @@ public class Mentoring extends BaseAudit {
 		findSession(date, startTime).unbook();
 	}
 
+	public void cleanupPastSessions(LocalDate today) {
+		sessions.removeIf(session -> session.getSessionDate().isBefore(today) && !session.isBooked());
+	}
 
 	public void addSessionsIfAbsent(List<MentoringSession> candidates) {
 		Set<LocalDateTime> existing = sessions.stream()

--- a/src/main/java/com/goggles/mentoring_service/domain/mentoring/repository/MentoringRepository.java
+++ b/src/main/java/com/goggles/mentoring_service/domain/mentoring/repository/MentoringRepository.java
@@ -20,4 +20,7 @@ public interface MentoringRepository {
 	Page<Mentoring> findAll(MentoringSearchCondition condition, Pageable pageable);
 
 	List<Mentoring> findActiveWithRepeatPatterns();
+
+	List<Mentoring> findWithExpiredNonBookedSessions(LocalDate today);
+
 }

--- a/src/main/java/com/goggles/mentoring_service/domain/mentoring/repository/MentoringRepository.java
+++ b/src/main/java/com/goggles/mentoring_service/domain/mentoring/repository/MentoringRepository.java
@@ -3,9 +3,12 @@ package com.goggles.mentoring_service.domain.mentoring.repository;
 import com.goggles.mentoring_service.domain.mentoring.Mentoring;
 import com.goggles.mentoring_service.domain.mentoring.MentoringId;
 import com.goggles.mentoring_service.domain.mentoring.MentoringSearchCondition;
+import com.goggles.mentoring_service.domain.mentoring.MentoringStatus;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
+import java.time.LocalDate;
+import java.util.List;
 import java.util.Optional;
 
 public interface MentoringRepository {
@@ -16,4 +19,5 @@ public interface MentoringRepository {
 
 	Page<Mentoring> findAll(MentoringSearchCondition condition, Pageable pageable);
 
+	List<Mentoring> findActiveWithRepeatPatterns();
 }

--- a/src/main/java/com/goggles/mentoring_service/infrastructure/persistence/BookingRepositoryImpl.java
+++ b/src/main/java/com/goggles/mentoring_service/infrastructure/persistence/BookingRepositoryImpl.java
@@ -38,4 +38,11 @@ public class BookingRepositoryImpl implements MentoringBookingRepository {
 	public Page<MentoringBooking> findByUser(BookingSearchCondition condition, Pageable pageable) {
 		return queryRepository.findByUser(condition, pageable);
 	}
+
+	@Override
+	public List<MentoringBooking> findPaymentCompletedWithApproachingSessions(
+			LocalDate thresholdDate, LocalTime thresholdTime) {
+		return jpaRepository.findByStatusWithApproachingSessions(
+				BookingStatus.PAYMENT_COMPLETED, thresholdDate, thresholdTime);
+	}
 }

--- a/src/main/java/com/goggles/mentoring_service/infrastructure/persistence/BookingRepositoryImpl.java
+++ b/src/main/java/com/goggles/mentoring_service/infrastructure/persistence/BookingRepositoryImpl.java
@@ -1,6 +1,7 @@
 package com.goggles.mentoring_service.infrastructure.persistence;
 
 import com.goggles.mentoring_service.domain.booking.BookingSearchCondition;
+import com.goggles.mentoring_service.domain.booking.BookingStatus;
 import com.goggles.mentoring_service.domain.booking.MentoringBooking;
 import com.goggles.mentoring_service.domain.booking.MentoringBookingId;
 import com.goggles.mentoring_service.domain.booking.repository.MentoringBookingRepository;
@@ -11,6 +12,9 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Repository;
 
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.util.List;
 import java.util.Optional;
 
 @Repository

--- a/src/main/java/com/goggles/mentoring_service/infrastructure/persistence/MentoringRepositoryImpl.java
+++ b/src/main/java/com/goggles/mentoring_service/infrastructure/persistence/MentoringRepositoryImpl.java
@@ -40,5 +40,9 @@ public class MentoringRepositoryImpl implements MentoringRepository {
 	public List<Mentoring> findActiveWithRepeatPatterns() {
 		return jpaRepository.findByStatusWithRepeatPatterns(MentoringStatus.ACTIVE);
 	}
+
+	@Override
+	public List<Mentoring> findWithExpiredNonBookedSessions(LocalDate today) {
+		return jpaRepository.findWithExpiredNonBookedSessions(today, SessionStatus.BOOKED);
 	}
 }

--- a/src/main/java/com/goggles/mentoring_service/infrastructure/persistence/MentoringRepositoryImpl.java
+++ b/src/main/java/com/goggles/mentoring_service/infrastructure/persistence/MentoringRepositoryImpl.java
@@ -1,8 +1,6 @@
 package com.goggles.mentoring_service.infrastructure.persistence;
 
-import com.goggles.mentoring_service.domain.mentoring.Mentoring;
-import com.goggles.mentoring_service.domain.mentoring.MentoringId;
-import com.goggles.mentoring_service.domain.mentoring.MentoringSearchCondition;
+import com.goggles.mentoring_service.domain.mentoring.*;
 import com.goggles.mentoring_service.domain.mentoring.repository.MentoringRepository;
 import com.goggles.mentoring_service.infrastructure.persistence.jpa.MentoringJpaRepository;
 import com.goggles.mentoring_service.infrastructure.persistence.jpa.MentoringQueryRepository;
@@ -11,6 +9,8 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Repository;
 
+import java.time.LocalDate;
+import java.util.List;
 import java.util.Optional;
 
 
@@ -34,5 +34,11 @@ public class MentoringRepositoryImpl implements MentoringRepository {
 	@Override
 	public Page<Mentoring> findAll(MentoringSearchCondition condition, Pageable pageable) {
 		return queryRepository.search(condition, pageable);
+	}
+
+	@Override
+	public List<Mentoring> findActiveWithRepeatPatterns() {
+		return jpaRepository.findByStatusWithRepeatPatterns(MentoringStatus.ACTIVE);
+	}
 	}
 }

--- a/src/main/java/com/goggles/mentoring_service/infrastructure/persistence/jpa/BookingJpaRepository.java
+++ b/src/main/java/com/goggles/mentoring_service/infrastructure/persistence/jpa/BookingJpaRepository.java
@@ -1,7 +1,24 @@
 package com.goggles.mentoring_service.infrastructure.persistence.jpa;
 
+import com.goggles.mentoring_service.domain.booking.BookingStatus;
 import com.goggles.mentoring_service.domain.booking.MentoringBooking;
 import com.goggles.mentoring_service.domain.booking.MentoringBookingId;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
-public interface BookingJpaRepository extends JpaRepository<MentoringBooking, MentoringBookingId> {}
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.util.List;
+
+public interface BookingJpaRepository extends JpaRepository<MentoringBooking, MentoringBookingId> {
+
+	@Query("SELECT DISTINCT b FROM MentoringBooking b JOIN b.bookingSessions s " +
+			"WHERE b.status = :status " +
+			"AND (s.sessionDate < :thresholdDate " +
+			"     OR (s.sessionDate = :thresholdDate AND s.sessionStartTime <= :thresholdTime))")
+	List<MentoringBooking> findByStatusWithApproachingSessions(
+			@Param("status") BookingStatus status,
+			@Param("thresholdDate") LocalDate thresholdDate,
+			@Param("thresholdTime") LocalTime thresholdTime);
+}

--- a/src/main/java/com/goggles/mentoring_service/infrastructure/persistence/jpa/MentoringJpaRepository.java
+++ b/src/main/java/com/goggles/mentoring_service/infrastructure/persistence/jpa/MentoringJpaRepository.java
@@ -2,6 +2,17 @@ package com.goggles.mentoring_service.infrastructure.persistence.jpa;
 
 import com.goggles.mentoring_service.domain.mentoring.Mentoring;
 import com.goggles.mentoring_service.domain.mentoring.MentoringId;
+import com.goggles.mentoring_service.domain.mentoring.MentoringStatus;
+import com.goggles.mentoring_service.domain.mentoring.SessionStatus;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.repository.query.Param;
 
-public interface MentoringJpaRepository extends JpaRepository<Mentoring, MentoringId> {}
+import java.time.LocalDate;
+import java.util.List;
+
+public interface MentoringJpaRepository extends JpaRepository<Mentoring, MentoringId> {
+
+	@Query("SELECT m FROM Mentoring m WHERE m.status = :status AND SIZE(m.repeatPatterns) > 0")
+	List<Mentoring> findByStatusWithRepeatPatterns(MentoringStatus status);
+}

--- a/src/main/java/com/goggles/mentoring_service/infrastructure/persistence/jpa/MentoringJpaRepository.java
+++ b/src/main/java/com/goggles/mentoring_service/infrastructure/persistence/jpa/MentoringJpaRepository.java
@@ -15,4 +15,10 @@ public interface MentoringJpaRepository extends JpaRepository<Mentoring, Mentori
 
 	@Query("SELECT m FROM Mentoring m WHERE m.status = :status AND SIZE(m.repeatPatterns) > 0")
 	List<Mentoring> findByStatusWithRepeatPatterns(MentoringStatus status);
+
+	@Query("SELECT DISTINCT m FROM Mentoring m JOIN m.sessions s " +
+			"WHERE s.sessionDate < :today AND s.status <> :booked")
+	List<Mentoring> findWithExpiredNonBookedSessions(
+			@Param("today") LocalDate today,
+			@Param("booked") SessionStatus booked);
 }

--- a/src/main/java/com/goggles/mentoring_service/infrastructure/scheduler/MentoringScheduler.java
+++ b/src/main/java/com/goggles/mentoring_service/infrastructure/scheduler/MentoringScheduler.java
@@ -1,0 +1,55 @@
+package com.goggles.mentoring_service.infrastructure.scheduler;
+
+import com.goggles.mentoring_service.application.service.BookingService;
+import com.goggles.mentoring_service.application.service.MentoringService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class MentoringScheduler {
+
+	private final BookingService bookingService;
+	private final MentoringService mentoringService;
+
+	@Scheduled(cron = "0 0 0 * * *")
+	public void generateDailyRepeatSessions() {
+		LocalDate tomorrow = LocalDate.now().plusDays(1);
+		try {
+			mentoringService.generateDailyRepeatSessions(tomorrow);
+			log.info("[스케쥴러] 반복 세션 생성 완료: {}", tomorrow);
+		} catch (Exception e) {
+			log.error("[스케쥴러] 반복 세션 생성 실패: {}", tomorrow, e);
+		}
+	}
+
+	@Scheduled(cron = "0 5 0 * * *")
+	public void cleanupExpiredSessions() {
+		LocalDate today = LocalDate.now();
+		try {
+			mentoringService.cleanupExpiredSessions(today);
+			log.info("[스케쥴러] 만료 슬롯 정리 완료: {} 이전", today);
+		} catch (Exception e) {
+			log.error("[스케쥴러] 만료 슬롯 정리 실패", e);
+		}
+	}
+	
+	@Scheduled(cron = "0 0 * * * *")
+	public void autoCancelUnapprovedBookings() {
+		LocalDateTime threshold = LocalDateTime.now().plusHours(24);
+		try {
+			int count = bookingService.autoCancelUnapproved(threshold);
+			if (count > 0) {
+				log.info("[스케쥴러] 미승인 예약 자동 취소: {}건", count);
+			}
+		} catch (Exception e) {
+			log.error("[스케쥴러] 미승인 예약 자동 취소 실패", e);
+		}
+	}
+}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -54,7 +54,7 @@ kafka:
       pending-approval: mentoring.booking.pending_approval.v1
     order:
       mentoring-completed: ${topics.order.mentoring-completed:order.mentoring-completed.v1}
-      mentoring-canceled: ${topics.order.mentoring-cancelled:order.mentoring-canceled.v1}
+      mentoring-canceled: ${topics.order.mentoring-canceled:order.mentoring-canceled.v1}
 
 resilience4j:
   circuitbreaker:

--- a/src/test/java/com/goggles/mentoring_service/application/service/BookingServiceTest.java
+++ b/src/test/java/com/goggles/mentoring_service/application/service/BookingServiceTest.java
@@ -28,6 +28,9 @@ import org.slf4j.LoggerFactory;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
@@ -41,6 +44,8 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.verify;
+
+import com.goggles.mentoring_service.domain.mentoring.SessionStatus;
 
 @ExtendWith(MockitoExtension.class)
 class BookingServiceTest {
@@ -398,5 +403,67 @@ class BookingServiceTest {
 		assertThat(result.getContent()).isEmpty();
 		assertThat(result.getTotalElements()).isZero();
 		verify(bookingRepository).findByUser(any(), any());
+	}
+
+	@Test
+	void autoCancelUnapproved_cancels_approaching_bookings() {
+		MentoringBooking booking = paymentCompletedBooking();
+		given(bookingRepository.findPaymentCompletedWithApproachingSessions(any(), any())).willReturn(
+				List.of(booking));
+		given(mentoringRepository.findById(any())).willReturn(Optional.empty());
+
+		LocalDateTime threshold = LocalDateTime.of(SESSION_DATE, SESSION_START_TIME);
+		int count = bookingService.autoCancelUnapproved(threshold);
+
+		log.info("[자동 취소] threshold={}, 취소 건수={}, 상태={}", threshold, count, booking.getStatus());
+		assertThat(count).isEqualTo(1);
+		assertThat(booking.getStatus()).isEqualTo(BookingStatus.CANCELED);
+	}
+
+	@Test
+	void autoCancelUnapproved_returns_zero_when_no_bookings() {
+		given(bookingRepository.findPaymentCompletedWithApproachingSessions(any(), any())).willReturn(
+				List.of());
+
+		int count = bookingService.autoCancelUnapproved(LocalDateTime.now().plusHours(24));
+
+		assertThat(count).isZero();
+	}
+
+	@Test
+	void autoCancelUnapproved_unbooks_mentoring_session() {
+		MentoringBooking booking = paymentCompletedBooking();
+		Mentoring mentoring = defaultMentoringBuilder()
+				.sessions(List.of(session(SESSION_DATE)))
+				.build();
+		mentoring.bookSession(SESSION_DATE, SESSION_START_TIME);
+
+		given(bookingRepository.findPaymentCompletedWithApproachingSessions(any(), any())).willReturn(
+				List.of(booking));
+		given(mentoringRepository.findById(any())).willReturn(Optional.of(mentoring));
+
+		bookingService.autoCancelUnapproved(LocalDateTime.of(SESSION_DATE, SESSION_START_TIME));
+
+		log.info("[자동 취소] 예약 상태={}, 세션 상태={}",
+				booking.getStatus(), mentoring.getSessions().getFirst().getStatus());
+		assertThat(booking.getStatus()).isEqualTo(BookingStatus.CANCELED);
+		assertThat(mentoring.getSessions().getFirst().getStatus()).isEqualTo(
+				com.goggles.mentoring_service.domain.mentoring.SessionStatus.AVAILABLE);
+	}
+
+	@Test
+	void autoCancelUnapproved_cancels_multiple_bookings() {
+		MentoringBooking booking1 = paymentCompletedBooking();
+		MentoringBooking booking2 = paymentCompletedBooking();
+		given(bookingRepository.findPaymentCompletedWithApproachingSessions(any(), any())).willReturn(
+				List.of(booking1, booking2));
+		given(mentoringRepository.findById(any())).willReturn(Optional.empty());
+
+		int count = bookingService.autoCancelUnapproved(LocalDateTime.now());
+
+		log.info("[자동 취소] 취소 건수={}", count);
+		assertThat(count).isEqualTo(2);
+		assertThat(booking1.getStatus()).isEqualTo(BookingStatus.CANCELED);
+		assertThat(booking2.getStatus()).isEqualTo(BookingStatus.CANCELED);
 	}
 }

--- a/src/test/java/com/goggles/mentoring_service/application/service/MentoringServiceIntegrationTest.java
+++ b/src/test/java/com/goggles/mentoring_service/application/service/MentoringServiceIntegrationTest.java
@@ -22,6 +22,7 @@ import org.springframework.test.context.ActiveProfiles;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.DayOfWeek;
+import java.time.LocalDate;
 import java.util.List;
 import java.util.UUID;
 
@@ -313,6 +314,51 @@ class MentoringServiceIntegrationTest {
 				.size());
 		assertThat(page2.getContent()).isEmpty();
 		assertThat(page2.getNumber()).isEqualTo(2);
+	}
+
+
+	@Test
+	void cleanupExpiredSessions_removes_nonBooked_and_preserves_booked() {
+		LocalDate past1 = LocalDate.of(2025, 1, 1);
+		LocalDate past2 = LocalDate.of(2025, 1, 2);
+
+		// 과거 AVAILABLE 세션 2개 — DISTINCT 동작 겸 검증
+		Mentoring withExpired = defaultMentoringBuilder()
+				.sessions(List.of(session(past1), session(past2)))
+				.build();
+		mentoringRepository.save(withExpired);
+
+		// 과거 BOOKED 세션 — 제거되지 않아야 함
+		Mentoring withBooked = defaultMentoringBuilder()
+				.sessions(List.of(session(past1)))
+				.build();
+		withBooked.bookSession(past1, START_TIME);
+		mentoringRepository.save(withBooked);
+
+		// 미래 세션만 — 쿼리 결과에 포함되지 않아야 함
+		Mentoring withFuture = defaultMentoringBuilder()
+				.sessions(List.of(session(SESSION_DATE_1)))
+				.build();
+		mentoringRepository.save(withFuture);
+
+		em.flush();
+		em.clear();
+
+		mentoringService.cleanupExpiredSessions(LocalDate.now());
+
+		em.flush();
+		em.clear();
+
+		assertThat(mentoringRepository.findById(withExpired.getMentoringId())
+				.orElseThrow().getSessions()).isEmpty();
+
+		List<MentoringSession> bookedSessions = mentoringRepository
+				.findById(withBooked.getMentoringId()).orElseThrow().getSessions();
+		assertThat(bookedSessions).hasSize(1);
+		assertThat(bookedSessions.get(0).getStatus()).isEqualTo(SessionStatus.BOOKED);
+
+		assertThat(mentoringRepository.findById(withFuture.getMentoringId())
+				.orElseThrow().getSessions()).hasSize(1);
 	}
 
 	// ── 헬퍼 ─────────────────────────────────────────────────────────────────

--- a/src/test/java/com/goggles/mentoring_service/application/service/MentoringServiceTest.java
+++ b/src/test/java/com/goggles/mentoring_service/application/service/MentoringServiceTest.java
@@ -10,6 +10,7 @@ import com.goggles.mentoring_service.domain.category.repository.MentoringCategor
 import com.goggles.mentoring_service.domain.mentoring.*;
 import com.goggles.mentoring_service.domain.mentoring.exception.MentoringNotFoundException;
 import com.goggles.mentoring_service.domain.mentoring.repository.MentoringRepository;
+import com.goggles.mentoring_service.domain.mentoring.SessionStatus;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -22,6 +23,7 @@ import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
 
 import java.time.DayOfWeek;
+import java.time.LocalDate;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
@@ -46,6 +48,9 @@ class MentoringServiceTest {
 
 	@Mock
 	private MentoringCategoryRepository categoryRepository;
+
+	@Mock
+	private HolidayProvider holidayProvider;
 
 	@Mock
 	private MentoringCategory category;
@@ -225,5 +230,110 @@ class MentoringServiceTest {
 				MentoringType.ONE_ON_ONE, Format.SINGLE, SESSION_COUNT, MAX_PARTICIPANTS, false,
 				PRICE, null, List.of(sessionSlot(SESSION_DATE_1)),
 				List.of(timeSchedules(DayOfWeek.MONDAY)));
+	}
+
+	// SESSION_DATE_1 = 2027-05-01 (토), 월 = 2027-05-03, 화 = 2027-05-04
+	private static final LocalDate MONDAY = LocalDate.of(2027, 5, 3);
+	private static final LocalDate TUESDAY = LocalDate.of(2027, 5, 4);
+
+	private Mentoring activeMultiMentoring(List<RepeatPattern> patterns,
+			List<MentoringSession> sessions) {
+		return defaultMentoringBuilder()
+				.format(Format.MULTI)
+				.sessionCount(2)
+				.status(MentoringStatus.ACTIVE)
+				.repeatPatterns(patterns)
+				.sessions(sessions)
+				.build();
+	}
+
+	@Test
+	void generateDailyRepeatSessions_adds_session_for_matching_day() {
+		Mentoring mentoring = activeMultiMentoring(
+				List.of(repeatPattern(DayOfWeek.MONDAY)), List.of());
+		given(mentoringRepository.findActiveWithRepeatPatterns()).willReturn(List.of(mentoring));
+
+		mentoringService.generateDailyRepeatSessions(MONDAY);
+
+		log.info("[슬롯 생성] {}: 월요일 패턴 → 세션 {}개", MONDAY, mentoring.getSessions().size());
+		assertThat(mentoring.getSessions()).hasSize(1);
+		assertThat(mentoring.getSessions().getFirst().getSessionDate()).isEqualTo(MONDAY);
+	}
+
+	@Test
+	void generateDailyRepeatSessions_no_session_for_non_matching_day() {
+		Mentoring mentoring = activeMultiMentoring(
+				List.of(repeatPattern(DayOfWeek.MONDAY)), List.of());
+		given(mentoringRepository.findActiveWithRepeatPatterns()).willReturn(List.of(mentoring));
+
+		mentoringService.generateDailyRepeatSessions(TUESDAY);
+
+		log.info("[슬롯 생성] {}: 월요일 패턴 + 화요일 대상 → 생성 없음", TUESDAY);
+		assertThat(mentoring.getSessions()).isEmpty();
+	}
+
+	@Test
+	void generateDailyRepeatSessions_skips_duplicate_sessions() {
+		Mentoring mentoring = activeMultiMentoring(
+				List.of(repeatPattern(DayOfWeek.MONDAY)), List.of(session(MONDAY)));
+		given(mentoringRepository.findActiveWithRepeatPatterns()).willReturn(List.of(mentoring));
+
+		mentoringService.generateDailyRepeatSessions(MONDAY);
+
+		log.info("[슬롯 생성] 이미 존재하는 슬롯 중복 추가 차단 → 세션 {}개", mentoring.getSessions().size());
+		assertThat(mentoring.getSessions()).hasSize(1);
+	}
+
+	@Test
+	void generateDailyRepeatSessions_does_nothing_when_no_mentorings() {
+		given(mentoringRepository.findActiveWithRepeatPatterns()).willReturn(List.of());
+
+		mentoringService.generateDailyRepeatSessions(MONDAY);
+
+	}
+
+	@Test
+	void cleanupExpiredSessions_removes_past_available_sessions() {
+		LocalDate today = LocalDate.of(2026, 6, 1);
+		LocalDate past = LocalDate.of(2026, 5, 1);
+		LocalDate future = LocalDate.of(2026, 7, 1);
+		Mentoring mentoring = defaultMentoringBuilder()
+				.sessions(List.of(session(past), session(future)))
+				.build();
+		given(mentoringRepository.findWithExpiredNonBookedSessions(today)).willReturn(
+				List.of(mentoring));
+
+		mentoringService.cleanupExpiredSessions(today);
+
+		log.info("[슬롯 정리] {} 이전 세션 제거 → 남은 세션: {}개", today,
+				mentoring.getSessions().size());
+		assertThat(mentoring.getSessions()).hasSize(1);
+		assertThat(mentoring.getSessions().getFirst().getSessionDate()).isEqualTo(future);
+	}
+
+	@Test
+	void cleanupExpiredSessions_keeps_booked_sessions() {
+		LocalDate today = LocalDate.of(2026, 6, 1);
+		LocalDate past = LocalDate.of(2026, 5, 1);
+		Mentoring mentoring = defaultMentoringBuilder()
+				.sessions(List.of(session(past)))
+				.build();
+		mentoring.bookSession(past, START_TIME);
+		given(mentoringRepository.findWithExpiredNonBookedSessions(today)).willReturn(
+				List.of(mentoring));
+
+		mentoringService.cleanupExpiredSessions(today);
+
+		assertThat(mentoring.getSessions()).hasSize(1);
+		assertThat(mentoring.getSessions().getFirst().getStatus()).isEqualTo(SessionStatus.BOOKED);
+	}
+
+	@Test
+	void cleanupExpiredSessions_does_nothing_when_no_mentorings() {
+		LocalDate today = LocalDate.now();
+		given(mentoringRepository.findWithExpiredNonBookedSessions(any())).willReturn(List.of());
+
+		mentoringService.cleanupExpiredSessions(today);
+
 	}
 }

--- a/src/test/java/com/goggles/mentoring_service/domain/mentoring/MentoringTest.java
+++ b/src/test/java/com/goggles/mentoring_service/domain/mentoring/MentoringTest.java
@@ -199,4 +199,74 @@ class MentoringTest {
 
 		assertThat(mentoring.getStatus()).isEqualTo(MentoringStatus.INACTIVE);
 	}
+
+	@Test
+	void cleanupPastSessions_removes_past_available_sessions() {
+		LocalDate today = LocalDate.of(2026, 6, 1);
+		LocalDate past = LocalDate.of(2026, 5, 1);
+		LocalDate future = LocalDate.of(2026, 7, 1);
+		mentoring.addSessions(List.of(session(past), session(future)));
+
+		mentoring.cleanupPastSessions(today);
+
+		assertThat(mentoring.getSessions()).hasSize(1);
+		assertThat(mentoring.getSessions().getFirst().getSessionDate()).isEqualTo(future);
+	}
+
+	@Test
+	void cleanupPastSessions_keeps_booked_sessions() {
+		LocalDate today = LocalDate.of(2026, 6, 1);
+		LocalDate past1 = LocalDate.of(2026, 5, 1);
+		LocalDate past2 = LocalDate.of(2026, 5, 2);
+		mentoring.addSessions(List.of(session(past1), session(past2)));
+		mentoring.bookSession(past1, START_TIME);
+
+		mentoring.cleanupPastSessions(today);
+
+		assertThat(mentoring.getSessions()).hasSize(1);
+		assertThat(mentoring.getSessions().getFirst().getSessionDate()).isEqualTo(past1);
+		assertThat(mentoring.getSessions().getFirst().getStatus()).isEqualTo(SessionStatus.BOOKED);
+	}
+
+	@Test
+	void cleanupPastSessions_keeps_today_sessions() {
+		LocalDate today = LocalDate.of(2026, 6, 1);
+		mentoring.addSessions(List.of(session(today)));
+
+		mentoring.cleanupPastSessions(today);
+
+		assertThat(mentoring.getSessions()).hasSize(1);
+	}
+
+	// ── addSessionsIfAbsent ───────────────────────────────────────────────────
+
+	@Test
+	void addSessionsIfAbsent_adds_only_new_sessions() {
+		mentoring.addSessions(List.of(session(SESSION_DATE_1)));
+
+		mentoring.addSessionsIfAbsent(List.of(session(SESSION_DATE_1), session(SESSION_DATE_2)));
+
+		assertThat(mentoring.getSessions()).hasSize(2);
+		assertThat(mentoring.getSessions().stream()
+				.map(MentoringSession::getSessionDate)
+				.toList()).containsExactlyInAnyOrder(SESSION_DATE_1, SESSION_DATE_2);
+	}
+
+	@Test
+	void addSessionsIfAbsent_skips_all_existing() {
+		mentoring.addSessions(List.of(session(SESSION_DATE_1)));
+
+		mentoring.addSessionsIfAbsent(List.of(session(SESSION_DATE_1)));
+
+		assertThat(mentoring.getSessions()).hasSize(1);
+	}
+
+	@Test
+	void addSessionsIfAbsent_empty_candidates_does_nothing() {
+		mentoring.addSessions(List.of(session(SESSION_DATE_1)));
+
+		mentoring.addSessionsIfAbsent(List.of());
+
+		assertThat(mentoring.getSessions()).hasSize(1);
+	}
 }


### PR DESCRIPTION
### 📌 관련 이슈
- close #40
### 💡 작업 내용
- 매일 0시 날짜가 지난 미예약 슬롯 정리 
- 다음 날 슬롯 자동 생성
- 매 정시 수락 대기 상태인데 세션 시작 24시간 전까지 멘토가 수락하지 않은 예약 자동 취소

### 🔍 변경 이유
- 

### 📝 리뷰 포인트 (선택)
- findWithExpiredNonBookedSessions 통합 테스트 필요


### 🧠 기타 참고 사항
(참고 문서, 스크린샷 등)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새 기능**
  * 멘토링 예약의 주문 기반 취소 워크플로우 추가
  * 반복 일정 멘토링을 위한 일일 자동 세션 생성 기능 추가
  * 승인 대기 중인 미납금 예약의 자동 취소 기능 추가
  
* **버그 수정**
  * Kafka SSL 트러스트스토어 복원 로직 개선 및 안정성 강화

* **개선 사항**
  * 예약 세션 라이프사이클 관리 최적화
  * 만료된 세션 자동 정리 기능 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->