### PR TITLE
[Feat]  분산 락

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -43,7 +43,9 @@ dependencyManagement {
 dependencies {
 
 	implementation 'org.springframework.boot:spring-boot-starter-web'
+	implementation 'org.springframework.boot:spring-boot-starter-aop'
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+	implementation 'org.redisson:redisson:3.27.2'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	runtimeOnly 'org.postgresql:postgresql'
 	compileOnly 'org.projectlombok:lombok'

--- a/src/main/java/com/goggles/mentoring_service/application/lock/DistributedLock.java
+++ b/src/main/java/com/goggles/mentoring_service/application/lock/DistributedLock.java
@@ -1,4 +1,4 @@
-package com.goggles.mentoring_service.infrastructure.lock;
+package com.goggles.mentoring_service.application.lock;
 
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;

--- a/src/main/java/com/goggles/mentoring_service/application/service/BookingService.java
+++ b/src/main/java/com/goggles/mentoring_service/application/service/BookingService.java
@@ -15,7 +15,7 @@ import com.goggles.mentoring_service.domain.mentoring.Mentoring;
 import com.goggles.mentoring_service.domain.mentoring.MentoringId;
 import com.goggles.mentoring_service.domain.mentoring.exception.MentoringNotFoundException;
 import com.goggles.mentoring_service.domain.mentoring.repository.MentoringRepository;
-import com.goggles.mentoring_service.infrastructure.lock.DistributedLock;
+import com.goggles.mentoring_service.application.lock.DistributedLock;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Sort;

--- a/src/main/java/com/goggles/mentoring_service/application/service/BookingService.java
+++ b/src/main/java/com/goggles/mentoring_service/application/service/BookingService.java
@@ -15,6 +15,7 @@ import com.goggles.mentoring_service.domain.mentoring.Mentoring;
 import com.goggles.mentoring_service.domain.mentoring.MentoringId;
 import com.goggles.mentoring_service.domain.mentoring.exception.MentoringNotFoundException;
 import com.goggles.mentoring_service.domain.mentoring.repository.MentoringRepository;
+import com.goggles.mentoring_service.infrastructure.lock.DistributedLock;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Sort;
@@ -34,6 +35,7 @@ public class BookingService {
 	private final MentoringRepository mentoringRepository;
 	private final BookingEvent events;
 
+	@DistributedLock(key = "'booking:' + #command.mentoringId()")
 	@Transactional
 	public BookingResult.Create createBooking(BookingCommand.Create command) {
 		MentoringId mentoringId = new MentoringId(command.mentoringId());
@@ -173,6 +175,7 @@ public class BookingService {
 		booking.completeSession(command.sessionId(), command.userId(), command.userType());
 	}
 
+	@DistributedLock(key = "'booking:reschedule:' + #command.bookingId()")
 	@Transactional
 	public void rescheduleSession(BookingCommand.RescheduleSession command) {
 		MentoringBooking booking = findBooking(command.bookingId());

--- a/src/main/java/com/goggles/mentoring_service/infrastructure/config/RedissonConfig.java
+++ b/src/main/java/com/goggles/mentoring_service/infrastructure/config/RedissonConfig.java
@@ -1,9 +1,11 @@
 package com.goggles.mentoring_service.infrastructure.config;
 
+import com.goggles.mentoring_service.infrastructure.lock.DistributedLockAspect;
 import org.redisson.Redisson;
 import org.redisson.api.RedissonClient;
 import org.redisson.config.Config;
 import org.redisson.config.SentinelServersConfig;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Bean;
@@ -40,7 +42,19 @@ public class RedissonConfig {
 		Config config = new Config();
 		String host = env.getProperty("spring.data.redis.host", "localhost");
 		String port = env.getProperty("spring.data.redis.port", "6379");
-		config.useSingleServer().setAddress("redis://" + host + ":" + port);
+		String password = env.getProperty("spring.data.redis.password");
+
+		var singleConfig = config.useSingleServer().setAddress("redis://" + host + ":" + port);
+		if (password != null) {
+			singleConfig.setPassword(password);
+		}
 		return Redisson.create(config);
+	}
+
+	@Bean
+	@ConditionalOnBean(RedissonClient.class)
+	@ConditionalOnMissingBean(DistributedLockAspect.class)
+	public DistributedLockAspect distributedLockAspect(RedissonClient redissonClient) {
+		return new DistributedLockAspect(redissonClient);
 	}
 }

--- a/src/main/java/com/goggles/mentoring_service/infrastructure/config/RedissonConfig.java
+++ b/src/main/java/com/goggles/mentoring_service/infrastructure/config/RedissonConfig.java
@@ -1,0 +1,46 @@
+package com.goggles.mentoring_service.infrastructure.config;
+
+import org.redisson.Redisson;
+import org.redisson.api.RedissonClient;
+import org.redisson.config.Config;
+import org.redisson.config.SentinelServersConfig;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.env.Environment;
+
+@Configuration
+public class RedissonConfig {
+
+	@Bean(destroyMethod = "shutdown")
+	@ConditionalOnProperty(prefix = "spring.data.redis.sentinel", name = "master")
+	public RedissonClient redissonSentinelClient(Environment env) {
+		Config config = new Config();
+		String master = env.getProperty("spring.data.redis.sentinel.master");
+		String[] nodes = env.getProperty("spring.data.redis.sentinel.nodes", String[].class,
+				new String[0]);
+		String password = env.getProperty("spring.data.redis.password");
+
+		SentinelServersConfig sentinelConfig = config.useSentinelServers().setMasterName(master);
+		for (String node : nodes) {
+			sentinelConfig.addSentinelAddress("redis://" + node);
+		}
+		if (password != null) {
+			sentinelConfig.setPassword(password);
+			sentinelConfig.setSentinelPassword(password);
+		}
+		return Redisson.create(config);
+	}
+
+	@Bean(destroyMethod = "shutdown")
+	@ConditionalOnProperty(prefix = "spring.data.redis", name = "host")
+	@ConditionalOnMissingBean(RedissonClient.class)
+	public RedissonClient redissonSingleClient(Environment env) {
+		Config config = new Config();
+		String host = env.getProperty("spring.data.redis.host", "localhost");
+		String port = env.getProperty("spring.data.redis.port", "6379");
+		config.useSingleServer().setAddress("redis://" + host + ":" + port);
+		return Redisson.create(config);
+	}
+}

--- a/src/main/java/com/goggles/mentoring_service/infrastructure/exception/DistributionLockException.java
+++ b/src/main/java/com/goggles/mentoring_service/infrastructure/exception/DistributionLockException.java
@@ -8,3 +8,4 @@ public class DistributionLockException extends ConflictException {
 		super(message);
 	}
 }
+

--- a/src/main/java/com/goggles/mentoring_service/infrastructure/exception/DistributionLockException.java
+++ b/src/main/java/com/goggles/mentoring_service/infrastructure/exception/DistributionLockException.java
@@ -1,0 +1,10 @@
+package com.goggles.mentoring_service.infrastructure.exception;
+
+import com.goggles.common.exception.ConflictException;
+
+public class DistributionLockException extends ConflictException {
+
+	public DistributionLockException(String message) {
+		super(message);
+	}
+}

--- a/src/main/java/com/goggles/mentoring_service/infrastructure/lock/DistributedLock.java
+++ b/src/main/java/com/goggles/mentoring_service/infrastructure/lock/DistributedLock.java
@@ -1,0 +1,20 @@
+package com.goggles.mentoring_service.infrastructure.lock;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import java.util.concurrent.TimeUnit;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface DistributedLock {
+
+	String key();
+
+	long waitTime() default 5L;
+
+	long leaseTime() default -1L;
+
+	TimeUnit timeUnit() default TimeUnit.SECONDS;
+}

--- a/src/main/java/com/goggles/mentoring_service/infrastructure/lock/DistributedLockAspect.java
+++ b/src/main/java/com/goggles/mentoring_service/infrastructure/lock/DistributedLockAspect.java
@@ -1,39 +1,30 @@
 package com.goggles.mentoring_service.infrastructure.lock;
 
-import com.goggles.common.exception.ConflictException;
+import com.goggles.mentoring_service.application.lock.DistributedLock;
 import com.goggles.mentoring_service.infrastructure.exception.DistributionLockException;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.aspectj.lang.ProceedingJoinPoint;
 import org.aspectj.lang.annotation.Around;
 import org.aspectj.lang.annotation.Aspect;
 import org.redisson.api.RLock;
 import org.redisson.api.RedissonClient;
-import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.core.Ordered;
 import org.springframework.core.annotation.Order;
-import org.springframework.stereotype.Component;
 
 @Slf4j
 @Aspect
-@Component
 @Order(Ordered.LOWEST_PRECEDENCE - 1)
+@RequiredArgsConstructor
 public class DistributedLockAspect {
 
 	private static final String LOCK_PREFIX = "lock:";
 
 	private final RedissonClient redissonClient;
 
-	public DistributedLockAspect(ObjectProvider<RedissonClient> provider) {
-		this.redissonClient = provider.getIfAvailable();
-	}
-
 	@Around("@annotation(distributedLock)")
 	public Object lock(ProceedingJoinPoint joinPoint, DistributedLock distributedLock)
 			throws Throwable {
-		if (redissonClient == null) {
-			return joinPoint.proceed();
-		}
-
 		String key = LOCK_PREFIX + LockKeyParser.parse(distributedLock.key(), joinPoint);
 		RLock lock = redissonClient.getLock(key);
 

--- a/src/main/java/com/goggles/mentoring_service/infrastructure/lock/DistributedLockAspect.java
+++ b/src/main/java/com/goggles/mentoring_service/infrastructure/lock/DistributedLockAspect.java
@@ -1,0 +1,63 @@
+package com.goggles.mentoring_service.infrastructure.lock;
+
+import com.goggles.common.exception.ConflictException;
+import com.goggles.mentoring_service.infrastructure.exception.DistributionLockException;
+import lombok.extern.slf4j.Slf4j;
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.redisson.api.RLock;
+import org.redisson.api.RedissonClient;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Aspect
+@Component
+@Order(Ordered.LOWEST_PRECEDENCE - 1)
+public class DistributedLockAspect {
+
+	private static final String LOCK_PREFIX = "lock:";
+
+	private final RedissonClient redissonClient;
+
+	public DistributedLockAspect(ObjectProvider<RedissonClient> provider) {
+		this.redissonClient = provider.getIfAvailable();
+	}
+
+	@Around("@annotation(distributedLock)")
+	public Object lock(ProceedingJoinPoint joinPoint, DistributedLock distributedLock)
+			throws Throwable {
+		if (redissonClient == null) {
+			return joinPoint.proceed();
+		}
+
+		String key = LOCK_PREFIX + LockKeyParser.parse(distributedLock.key(), joinPoint);
+		RLock lock = redissonClient.getLock(key);
+
+		boolean acquired = tryAcquire(lock, distributedLock);
+		if (!acquired) {
+			log.warn("Distributed lock acquisition timed out. key={}", key);
+			throw new DistributionLockException("예약 처리 중입니다. 잠시 후 다시 시도해주세요.");
+		}
+
+		try {
+			return joinPoint.proceed();
+		} finally {
+			if (lock.isHeldByCurrentThread()) {
+				lock.unlock();
+			}
+		}
+	}
+
+	private boolean tryAcquire(RLock lock, DistributedLock distributedLock)
+			throws InterruptedException {
+		if (distributedLock.leaseTime() < 0) {
+			return lock.tryLock(distributedLock.waitTime(), distributedLock.timeUnit());
+		}
+		return lock.tryLock(distributedLock.waitTime(), distributedLock.leaseTime(),
+				distributedLock.timeUnit());
+	}
+}

--- a/src/main/java/com/goggles/mentoring_service/infrastructure/lock/LockKeyParser.java
+++ b/src/main/java/com/goggles/mentoring_service/infrastructure/lock/LockKeyParser.java
@@ -1,0 +1,37 @@
+package com.goggles.mentoring_service.infrastructure.lock;
+
+import com.goggles.mentoring_service.infrastructure.exception.DistributionLockException;
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.reflect.MethodSignature;
+import org.springframework.expression.EvaluationContext;
+import org.springframework.expression.ExpressionParser;
+import org.springframework.expression.spel.standard.SpelExpressionParser;
+import org.springframework.expression.spel.support.SimpleEvaluationContext;
+
+class LockKeyParser {
+
+	private static final ExpressionParser PARSER = new SpelExpressionParser();
+
+	static String parse(String expression, ProceedingJoinPoint joinPoint) {
+		if (!expression.contains("#")) {
+			return expression;
+		}
+		MethodSignature signature = (MethodSignature) joinPoint.getSignature();
+		String[] paramNames = signature.getParameterNames();
+		Object[] args = joinPoint.getArgs();
+
+		EvaluationContext context = SimpleEvaluationContext.forReadOnlyDataBinding()
+				.withInstanceMethods()
+				.build();
+		for (int i = 0; i < paramNames.length; i++) {
+			context.setVariable(paramNames[i], args[i]);
+		}
+
+		String result = PARSER.parseExpression(expression).getValue(context, String.class);
+		if (result == null) {
+			throw new DistributionLockException(
+					"@DistributedLock key expression evaluated to null: " + expression);
+		}
+		return result;
+	}
+}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -106,6 +106,12 @@ spring:
   jpa:
     hibernate:
       ddl-auto: create
+
+  data:
+    redis:
+      host: localhost
+      port: 6379
+
 management:
   tracing:
     sampling:

--- a/src/test/java/com/goggles/mentoring_service/application/service/BookingConcurrencyTest.java
+++ b/src/test/java/com/goggles/mentoring_service/application/service/BookingConcurrencyTest.java
@@ -9,6 +9,7 @@ import com.goggles.mentoring_service.domain.category.MentoringCategory;
 import com.goggles.mentoring_service.domain.category.repository.MentoringCategoryRepository;
 import com.goggles.mentoring_service.domain.mentoring.*;
 import com.goggles.mentoring_service.domain.mentoring.repository.MentoringRepository;
+import com.goggles.mentoring_service.infrastructure.lock.DistributedLockAspect;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.redisson.api.RLock;
@@ -16,7 +17,8 @@ import org.redisson.api.RedissonClient;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Import;
 import org.springframework.test.context.ActiveProfiles;
 
@@ -34,11 +36,25 @@ import static org.mockito.Mockito.*;
 
 @SpringBootTest
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.ANY)
-@Import(TestAuditConfig.class)
+@Import({TestAuditConfig.class, BookingConcurrencyTest.FakeLockConfig.class})
 @ActiveProfiles("test")
 class BookingConcurrencyTest {
 
-	@MockitoBean
+	@TestConfiguration
+	static class FakeLockConfig {
+
+		@Bean
+		public RedissonClient fakeRedissonClient() {
+			return mock(RedissonClient.class);
+		}
+
+		@Bean
+		public DistributedLockAspect distributedLockAspect(RedissonClient fakeRedissonClient) {
+			return new DistributedLockAspect(fakeRedissonClient);
+		}
+	}
+
+	@Autowired
 	private RedissonClient redissonClient;
 
 	@Autowired
@@ -49,7 +65,8 @@ class BookingConcurrencyTest {
 	private MentoringCategoryRepository categoryRepository;
 
 	private UUID mentoringId;
-	private final ConcurrentHashMap<String, java.util.concurrent.locks.ReentrantLock> lockMap = new ConcurrentHashMap<>();
+	private final ConcurrentHashMap<String, java.util.concurrent.locks.ReentrantLock> lockMap =
+			new ConcurrentHashMap<>();
 
 	@BeforeEach
 	void setUp() throws InterruptedException {
@@ -72,8 +89,7 @@ class BookingConcurrencyTest {
 				ready.countDown();
 				try {
 					start.await();
-					BookingCommand.Create command = bookingCommand(mentoringId, menteeId);
-					bookingService.createBooking(command);
+					bookingService.createBooking(bookingCommand(mentoringId, menteeId));
 					successCount.incrementAndGet();
 				} catch (Exception ignored) {
 				}

--- a/src/test/java/com/goggles/mentoring_service/application/service/BookingConcurrencyTest.java
+++ b/src/test/java/com/goggles/mentoring_service/application/service/BookingConcurrencyTest.java
@@ -1,0 +1,138 @@
+package com.goggles.mentoring_service.application.service;
+
+import com.goggles.mentoring_service.application.command.BookingCommand;
+import com.goggles.mentoring_service.application.command.MenteeInfo;
+import com.goggles.mentoring_service.config.TestAuditConfig;
+import com.goggles.mentoring_service.domain._common.UserType;
+import com.goggles.mentoring_service.domain.booking.SessionSlot;
+import com.goggles.mentoring_service.domain.category.MentoringCategory;
+import com.goggles.mentoring_service.domain.category.repository.MentoringCategoryRepository;
+import com.goggles.mentoring_service.domain.mentoring.*;
+import com.goggles.mentoring_service.domain.mentoring.repository.MentoringRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.redisson.api.RLock;
+import org.redisson.api.RedissonClient;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.*;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static com.goggles.mentoring_service.domain.mentoring.MentoringFixture.*;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.*;
+
+@SpringBootTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.ANY)
+@Import(TestAuditConfig.class)
+@ActiveProfiles("test")
+class BookingConcurrencyTest {
+
+	@MockitoBean
+	private RedissonClient redissonClient;
+
+	@Autowired
+	private BookingService bookingService;
+	@Autowired
+	private MentoringRepository mentoringRepository;
+	@Autowired
+	private MentoringCategoryRepository categoryRepository;
+
+	private UUID mentoringId;
+	private final ConcurrentHashMap<String, java.util.concurrent.locks.ReentrantLock> lockMap = new ConcurrentHashMap<>();
+
+	@BeforeEach
+	void setUp() throws InterruptedException {
+		lockMap.clear();
+		setupFakeLock();
+		mentoringId = saveMentoringWithSession();
+	}
+
+	@Test
+	void createBooking_concurrentRequests_onlyOneSucceeds() throws InterruptedException {
+		int threadCount = 5;
+		ExecutorService executor = Executors.newFixedThreadPool(threadCount);
+		CountDownLatch ready = new CountDownLatch(threadCount);
+		CountDownLatch start = new CountDownLatch(1);
+		AtomicInteger successCount = new AtomicInteger();
+
+		for (int i = 0; i < threadCount; i++) {
+			UUID menteeId = UUID.randomUUID();
+			executor.submit(() -> {
+				ready.countDown();
+				try {
+					start.await();
+					BookingCommand.Create command = bookingCommand(mentoringId, menteeId);
+					bookingService.createBooking(command);
+					successCount.incrementAndGet();
+				} catch (Exception ignored) {
+				}
+			});
+		}
+
+		ready.await();
+		start.countDown();
+		executor.shutdown();
+		boolean finished = executor.awaitTermination(30, TimeUnit.SECONDS);
+		assertThat(finished).as("모든 스레드가 30초 내에 완료되어야 합니다").isTrue();
+
+		assertThat(successCount.get()).isEqualTo(1);
+	}
+
+	// ── helpers ──────────────────────────────────────────────────────────────
+
+	private void setupFakeLock() throws InterruptedException {
+		when(redissonClient.getLock(anyString())).thenAnswer(inv -> {
+			String key = inv.getArgument(0);
+			java.util.concurrent.locks.ReentrantLock javaLock =
+					lockMap.computeIfAbsent(key, k -> new java.util.concurrent.locks.ReentrantLock());
+
+			RLock rLock = mock(RLock.class);
+			when(rLock.tryLock(anyLong(), any(TimeUnit.class))).thenAnswer(i ->
+					javaLock.tryLock(i.<Long>getArgument(0), i.getArgument(1)));
+			when(rLock.tryLock(anyLong(), anyLong(), any(TimeUnit.class))).thenAnswer(i ->
+					javaLock.tryLock(i.<Long>getArgument(0), i.<TimeUnit>getArgument(2)));
+			when(rLock.isHeldByCurrentThread()).thenAnswer(i -> javaLock.isHeldByCurrentThread());
+			doAnswer(i -> {
+				if (javaLock.isHeldByCurrentThread()) javaLock.unlock();
+				return null;
+			}).when(rLock).unlock();
+
+			return rLock;
+		});
+	}
+
+	private UUID saveMentoringWithSession() {
+		MentoringCategory category =
+				MentoringCategory.create(MENTOR_ID, UserType.MASTER, CATEGORY_NAME, CATEGORY_CODE);
+		categoryRepository.save(category);
+
+		Mentoring mentoring = defaultMentoringBuilder()
+				.categoryId(category.getMentoringCategoryId().categoryId())
+				.categoryName(category.getName())
+				.categoryCode(category.getCode())
+				.format(Format.SINGLE)
+				.mentoringType(MentoringType.ONE_ON_ONE)
+				.sessions(List.of(session(SESSION_DATE_1)))
+				.build();
+		mentoringRepository.save(mentoring);
+		return mentoring.getMentoringId().mentoringId();
+	}
+
+	private BookingCommand.Create bookingCommand(UUID mentoringId, UUID menteeId) {
+		MenteeInfo menteeInfo = new MenteeInfo(menteeId, UserType.STUDENT, "멘티");
+		SessionSlot slot = sessionSlot(SESSION_DATE_1);
+		return new BookingCommand.Create(menteeInfo, mentoringId, List.of(slot), "테스트",
+				UUID.randomUUID());
+	}
+}

--- a/src/test/java/com/goggles/mentoring_service/infrastructure/lock/DistributedLockAspectTest.java
+++ b/src/test/java/com/goggles/mentoring_service/infrastructure/lock/DistributedLockAspectTest.java
@@ -1,0 +1,149 @@
+package com.goggles.mentoring_service.infrastructure.lock;
+
+import com.goggles.mentoring_service.application.lock.DistributedLock;
+import com.goggles.mentoring_service.infrastructure.exception.DistributionLockException;
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.reflect.MethodSignature;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.redisson.api.RLock;
+import org.redisson.api.RedissonClient;
+import org.springframework.beans.factory.ObjectProvider;
+
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.*;
+
+class DistributedLockAspectTest {
+
+	private RedissonClient redissonClient;
+	private DistributedLockAspect aspect;
+
+	@BeforeEach
+	void setUp() {
+		redissonClient = mock(RedissonClient.class);
+		ObjectProvider<RedissonClient> provider = mock(ObjectProvider.class);
+		when(provider.getIfAvailable()).thenReturn(redissonClient);
+		aspect = new DistributedLockAspect(provider);
+	}
+
+	@Test
+	void lock_whenRedisUnavailable_proceedsWithoutLock() throws Throwable {
+		ObjectProvider<RedissonClient> emptyProvider = mock(ObjectProvider.class);
+		when(emptyProvider.getIfAvailable()).thenReturn(null);
+		DistributedLockAspect noRedisAspect = new DistributedLockAspect(emptyProvider);
+
+		ProceedingJoinPoint joinPoint = mockJoinPoint("result", new String[]{}, new Object[]{});
+		DistributedLock annotation = mockAnnotation("static-key", 5L, -1L);
+
+		Object result = noRedisAspect.lock(joinPoint, annotation);
+
+		assertThat(result).isEqualTo("result");
+		verifyNoInteractions(redissonClient);
+	}
+
+	@Test
+	void lock_whenAcquired_executesAndReturnsResult() throws Throwable {
+		RLock rLock = mockAcquiredLock();
+		when(redissonClient.getLock("lock:booking:test-id")).thenReturn(rLock);
+
+		// joinPoint에 'id' 파라미터를 포함해야 SpEL이 올바르게 평가됨
+		ProceedingJoinPoint joinPoint =
+				mockJoinPoint("expected", new String[]{"id"}, new Object[]{"test-id"});
+		DistributedLock annotation = mockAnnotation("'booking:' + #id", 5L, -1L);
+
+		Object result = aspect.lock(joinPoint, annotation);
+
+		assertThat(result).isEqualTo("expected");
+		verify(rLock).unlock();
+	}
+
+	@Test
+	void lock_whenNotAcquired_throwsConflictException() throws Throwable {
+		RLock rLock = mockFailedLock();
+		when(redissonClient.getLock(anyString())).thenReturn(rLock);
+
+		ProceedingJoinPoint joinPoint = mockJoinPoint("result", new String[]{}, new Object[]{});
+		DistributedLock annotation = mockAnnotation("static-key", 1L, -1L);
+
+		assertThatThrownBy(() -> aspect.lock(joinPoint, annotation))
+				.isInstanceOf(DistributionLockException.class);
+
+		verify(joinPoint, never()).proceed();
+		verify(rLock, never()).unlock();
+	}
+
+	@Test
+	void lock_whenMethodThrows_unlocksAndRethrows() throws Throwable {
+		RLock rLock = mockAcquiredLock();
+		when(redissonClient.getLock(anyString())).thenReturn(rLock);
+
+		ProceedingJoinPoint joinPoint = mockJoinPoint(null, new String[]{}, new Object[]{});
+		when(joinPoint.proceed()).thenThrow(new RuntimeException("도메인 오류"));
+		DistributedLock annotation = mockAnnotation("static-key", 5L, -1L);
+
+		assertThatThrownBy(() -> aspect.lock(joinPoint, annotation))
+				.isInstanceOf(RuntimeException.class)
+				.hasMessage("도메인 오류");
+
+		verify(rLock).unlock();
+	}
+
+	@Test
+	void lock_withExplicitLeaseTime_usesThreeParamTryLock() throws Throwable {
+		RLock rLock = mock(RLock.class);
+		when(rLock.tryLock(anyLong(), anyLong(), any(TimeUnit.class))).thenReturn(true);
+		when(rLock.isHeldByCurrentThread()).thenReturn(true);
+		when(redissonClient.getLock(anyString())).thenReturn(rLock);
+
+		ProceedingJoinPoint joinPoint = mockJoinPoint("result", new String[]{}, new Object[]{});
+		DistributedLock annotation = mockAnnotation("static-key", 5L, 30L);
+
+		aspect.lock(joinPoint, annotation);
+
+		verify(rLock).tryLock(5L, 30L, TimeUnit.SECONDS);
+		verify(rLock, never()).tryLock(anyLong(), any(TimeUnit.class));
+	}
+
+	// ── helpers ──────────────────────────────────────────────────────────────
+
+	private RLock mockAcquiredLock() throws InterruptedException {
+		RLock rLock = mock(RLock.class);
+		when(rLock.tryLock(anyLong(), any(TimeUnit.class))).thenReturn(true);
+		when(rLock.isHeldByCurrentThread()).thenReturn(true);
+		return rLock;
+	}
+
+	private RLock mockFailedLock() throws InterruptedException {
+		RLock rLock = mock(RLock.class);
+		when(rLock.tryLock(anyLong(), any(TimeUnit.class))).thenReturn(false);
+		when(rLock.isHeldByCurrentThread()).thenReturn(false);
+		return rLock;
+	}
+
+	private ProceedingJoinPoint mockJoinPoint(Object returnValue, String[] paramNames,
+			Object[] args) throws Throwable {
+		MethodSignature signature = mock(MethodSignature.class);
+		when(signature.getParameterNames()).thenReturn(paramNames);
+
+		ProceedingJoinPoint joinPoint = mock(ProceedingJoinPoint.class);
+		when(joinPoint.getSignature()).thenReturn(signature);
+		when(joinPoint.getArgs()).thenReturn(args);
+		when(joinPoint.proceed()).thenReturn(returnValue);
+		return joinPoint;
+	}
+
+	private DistributedLock mockAnnotation(String key, long waitTime, long leaseTime) {
+		DistributedLock annotation = mock(DistributedLock.class);
+		when(annotation.key()).thenReturn(key);
+		when(annotation.waitTime()).thenReturn(waitTime);
+		when(annotation.leaseTime()).thenReturn(leaseTime);
+		when(annotation.timeUnit()).thenReturn(TimeUnit.SECONDS);
+		return annotation;
+	}
+}

--- a/src/test/java/com/goggles/mentoring_service/infrastructure/lock/DistributedLockAspectTest.java
+++ b/src/test/java/com/goggles/mentoring_service/infrastructure/lock/DistributedLockAspectTest.java
@@ -8,7 +8,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.redisson.api.RLock;
 import org.redisson.api.RedissonClient;
-import org.springframework.beans.factory.ObjectProvider;
 
 import java.util.concurrent.TimeUnit;
 
@@ -27,24 +26,7 @@ class DistributedLockAspectTest {
 	@BeforeEach
 	void setUp() {
 		redissonClient = mock(RedissonClient.class);
-		ObjectProvider<RedissonClient> provider = mock(ObjectProvider.class);
-		when(provider.getIfAvailable()).thenReturn(redissonClient);
-		aspect = new DistributedLockAspect(provider);
-	}
-
-	@Test
-	void lock_whenRedisUnavailable_proceedsWithoutLock() throws Throwable {
-		ObjectProvider<RedissonClient> emptyProvider = mock(ObjectProvider.class);
-		when(emptyProvider.getIfAvailable()).thenReturn(null);
-		DistributedLockAspect noRedisAspect = new DistributedLockAspect(emptyProvider);
-
-		ProceedingJoinPoint joinPoint = mockJoinPoint("result", new String[]{}, new Object[]{});
-		DistributedLock annotation = mockAnnotation("static-key", 5L, -1L);
-
-		Object result = noRedisAspect.lock(joinPoint, annotation);
-
-		assertThat(result).isEqualTo("result");
-		verifyNoInteractions(redissonClient);
+		aspect = new DistributedLockAspect(redissonClient);
 	}
 
 	@Test
@@ -52,7 +34,6 @@ class DistributedLockAspectTest {
 		RLock rLock = mockAcquiredLock();
 		when(redissonClient.getLock("lock:booking:test-id")).thenReturn(rLock);
 
-		// joinPoint에 'id' 파라미터를 포함해야 SpEL이 올바르게 평가됨
 		ProceedingJoinPoint joinPoint =
 				mockJoinPoint("expected", new String[]{"id"}, new Object[]{"test-id"});
 		DistributedLock annotation = mockAnnotation("'booking:' + #id", 5L, -1L);
@@ -64,7 +45,7 @@ class DistributedLockAspectTest {
 	}
 
 	@Test
-	void lock_whenNotAcquired_throwsConflictException() throws Throwable {
+	void lock_whenNotAcquired_throwsDistributionLockException() throws Throwable {
 		RLock rLock = mockFailedLock();
 		when(redissonClient.getLock(anyString())).thenReturn(rLock);
 

--- a/src/test/java/com/goggles/mentoring_service/infrastructure/lock/LockKeyParserTest.java
+++ b/src/test/java/com/goggles/mentoring_service/infrastructure/lock/LockKeyParserTest.java
@@ -1,0 +1,74 @@
+package com.goggles.mentoring_service.infrastructure.lock;
+
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.reflect.MethodSignature;
+import org.junit.jupiter.api.Test;
+
+import com.goggles.mentoring_service.infrastructure.exception.DistributionLockException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class LockKeyParserTest {
+
+	@Test
+	void parse_staticKey_returnsAsIs() {
+		ProceedingJoinPoint joinPoint = mock(ProceedingJoinPoint.class);
+
+		String result = LockKeyParser.parse("booking:fixed-key", joinPoint);
+
+		assertThat(result).isEqualTo("booking:fixed-key");
+	}
+
+	@Test
+	void parse_spelWithStringConcatenation_resolvesCorrectly() {
+		String mentoringId = "abc-123";
+		ProceedingJoinPoint joinPoint = mockJoinPoint(new String[]{"command"}, new Object[]{new StubCommand(mentoringId)});
+
+		String result = LockKeyParser.parse("'booking:' + #command.id()", joinPoint);
+
+		assertThat(result).isEqualTo("booking:abc-123");
+	}
+
+	@Test
+	void parse_spelAccessingField_resolvesCorrectly() {
+		ProceedingJoinPoint joinPoint = mockJoinPoint(new String[]{"value"}, new Object[]{"hello"});
+
+		String result = LockKeyParser.parse("#value", joinPoint);
+
+		assertThat(result).isEqualTo("hello");
+	}
+
+	@Test
+	void parse_spelEvaluatesToNull_throwsException() {
+		ProceedingJoinPoint joinPoint = mockJoinPoint(new String[]{"command"}, new Object[]{new StubCommand(null)});
+
+		assertThatThrownBy(() -> LockKeyParser.parse("#command.id()", joinPoint))
+				.isInstanceOf(DistributionLockException.class)
+				.hasMessageContaining("null");
+	}
+
+	private ProceedingJoinPoint mockJoinPoint(String[] paramNames, Object[] args) {
+		MethodSignature signature = mock(MethodSignature.class);
+		when(signature.getParameterNames()).thenReturn(paramNames);
+
+		ProceedingJoinPoint joinPoint = mock(ProceedingJoinPoint.class);
+		when(joinPoint.getSignature()).thenReturn(signature);
+		when(joinPoint.getArgs()).thenReturn(args);
+		return joinPoint;
+	}
+
+	static class StubCommand {
+		private final String idValue;
+
+		StubCommand(String idValue) {
+			this.idValue = idValue;
+		}
+
+		public String id() {
+			return idValue;
+		}
+	}
+}


### PR DESCRIPTION
### 📌 관련 이슈
- close #39 

### 💡 작업 내용
  - 동시에 같은 시간대에 예약 요청이 몰렸을 때 중복 예약을 막는 분산락 적용
  - 예약 생성, 일정 변경 시 락을 걸어 한 번에 한 요청만 처리되도록 제한

### 🔍 변경 이유
 - 여러 사용자가 동시에 같은 슬롯을 예약하면 둘 다 "사용 가능" 상태로 읽고 둘 다 예약에 성공하는 문제가 있었음
- 분산 서버 환경에서는 DB 단에서 막기 어려워 Redis 락으로 직렬화 처리

### 📝 리뷰 포인트 (선택)
- 락이 트랜잭션보다 바깥에서 걸리는 구조인지 확인

### 🧠 기타 참고 사항
(참고 문서, 스크린샷 등)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **인프라 개선**
  * 예약 생성 및 세션 재스케줄링 작업에 분산 잠금 메커니즘을 추가하여 동시성 충돌로부터 보호합니다.
  * Redis 지원을 추가하여 분산 환경에서의 안정적인 잠금 처리를 가능하게 합니다.

* **테스트**
  * 동시 요청 시나리오에 대한 예약 기능의 신뢰성을 검증하는 통합 테스트를 추가합니다.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/9oogle/mentoring-service/pull/42)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->